### PR TITLE
[FEAT] Response custom, CustomException 핸들러 추가

### DIFF
--- a/src/main/java/maddori/keygo/common/exception/CustomException.java
+++ b/src/main/java/maddori/keygo/common/exception/CustomException.java
@@ -1,0 +1,11 @@
+package maddori.keygo.common.exception;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import maddori.keygo.common.response.ResponseCode;
+
+@Getter
+@AllArgsConstructor
+public class CustomException extends RuntimeException{
+    private final ResponseCode responseCode;
+}

--- a/src/main/java/maddori/keygo/common/exception/GlobalExceptionHandler.java
+++ b/src/main/java/maddori/keygo/common/exception/GlobalExceptionHandler.java
@@ -1,0 +1,15 @@
+package maddori.keygo.common.exception;
+
+import maddori.keygo.common.response.BasicResponse;
+import maddori.keygo.common.response.FailResponse;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.ControllerAdvice;
+import org.springframework.web.bind.annotation.ExceptionHandler;
+
+@ControllerAdvice
+public class GlobalExceptionHandler {
+    @ExceptionHandler(CustomException.class)
+    protected ResponseEntity<BasicResponse> handleCustomException(CustomException e) {
+        return FailResponse.toResponseEntity(e.getResponseCode());
+    }
+}

--- a/src/main/java/maddori/keygo/common/response/BasicResponse.java
+++ b/src/main/java/maddori/keygo/common/response/BasicResponse.java
@@ -1,0 +1,13 @@
+package maddori.keygo.common.response;
+
+import lombok.Getter;
+import lombok.Setter;
+import lombok.experimental.SuperBuilder;
+
+@Getter
+@Setter
+@SuperBuilder
+public abstract class BasicResponse {
+    private final boolean success;
+    private final String message;
+}

--- a/src/main/java/maddori/keygo/common/response/FailResponse.java
+++ b/src/main/java/maddori/keygo/common/response/FailResponse.java
@@ -13,7 +13,7 @@ public class FailResponse extends BasicResponse{
     public static ResponseEntity<BasicResponse> toResponseEntity(ResponseCode responseCode) {
         return ResponseEntity
                 .status(responseCode.getHttpStatus())
-                .body(SuccessResponse.builder()
+                .body(FailResponse.builder()
                         .success(responseCode.getSuccess())
                         .message(responseCode.getMessage())
                         .build()

--- a/src/main/java/maddori/keygo/common/response/FailResponse.java
+++ b/src/main/java/maddori/keygo/common/response/FailResponse.java
@@ -1,0 +1,22 @@
+package maddori.keygo.common.response;
+
+import lombok.Getter;
+import lombok.Setter;
+import lombok.experimental.SuperBuilder;
+import org.springframework.http.ResponseEntity;
+
+@SuperBuilder
+@Getter
+@Setter
+public class FailResponse extends BasicResponse{
+
+    public static ResponseEntity<BasicResponse> toResponseEntity(ResponseCode responseCode) {
+        return ResponseEntity
+                .status(responseCode.getHttpStatus())
+                .body(SuccessResponse.builder()
+                        .success(responseCode.getSuccess())
+                        .message(responseCode.getMessage())
+                        .build()
+                );
+    }
+}

--- a/src/main/java/maddori/keygo/common/response/ResponseCode.java
+++ b/src/main/java/maddori/keygo/common/response/ResponseCode.java
@@ -37,7 +37,6 @@ public enum ResponseCode {
     PROFILE_IMAGE_FORMAT_ERROR(HttpStatus.BAD_REQUEST, false, "이미지 파일만 업로드할 수 있습니다"),
     GET_USER_TEAM_LIST_SUCCESS(HttpStatus.OK, true, "유저의 팀 목록 가져오기 성공"),
     ALREADY_TEAM_MEMBER(HttpStatus.BAD_REQUEST, false, "이미 유저가 해당 팀에 합류된 상태"),
-    USER_TEAM_WITHDRAW(HttpStatus.BAD_REQUEST, false, "유저와 팀 정보가 잘못됨"),
 
     // reflection
     UPDATE_REFLECTION_DETAIL_SUCCESS(HttpStatus.OK, true, "회고 디테일 정보 추가 성공"),
@@ -70,6 +69,8 @@ public enum ResponseCode {
     UPDATE_FEEDBACK_SUCCESS(HttpStatus.CREATED, true, "피드백 수정 성공"),
     UPDATE_FEEDBACK_OTHERS_ERROR(HttpStatus.BAD_REQUEST, false, "타 유저가 작성한 피드백에 대한 수정 권한 없음"),
     NOT_INCLUDED_FEEDBACK(HttpStatus.BAD_REQUEST, false, "피드백이 회고에 속하지 않음");
+
+    // 입력값 형식 관련
 
     private final HttpStatus httpStatus;
     private final Boolean success;

--- a/src/main/java/maddori/keygo/common/response/ResponseCode.java
+++ b/src/main/java/maddori/keygo/common/response/ResponseCode.java
@@ -1,0 +1,17 @@
+package maddori.keygo.common.response;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import org.springframework.http.HttpStatus;
+
+@Getter
+@AllArgsConstructor
+public enum ResponseCode {
+
+    //team
+    GET_TEAM_INFO_SUCCESS(HttpStatus.OK, true, "팀 정보 가져오기 성공");
+
+    private final HttpStatus httpStatus;
+    private final Boolean success;
+    private final String message;
+}

--- a/src/main/java/maddori/keygo/common/response/ResponseCode.java
+++ b/src/main/java/maddori/keygo/common/response/ResponseCode.java
@@ -7,9 +7,69 @@ import org.springframework.http.HttpStatus;
 @Getter
 @AllArgsConstructor
 public enum ResponseCode {
+    // common
+    INTERNAL_SERVER_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, false, "서버 내부 오류"),
+    BAD_REQUEST(HttpStatus.BAD_REQUEST, false, "요청을 잘못 보냈습니다."),
+    PAGE_NOT_FOUND(HttpStatus.BAD_REQUEST, false, "요청하신 페이지를 찾을 수 없습니다"),
+    NEED_LOGIN(HttpStatus.BAD_REQUEST, false, "로그인이 필요합니다."),
+    NO_CONTENT(HttpStatus.BAD_REQUEST, false, "데이터가 없습니다."),
+    REPEATED_VALUE(HttpStatus.BAD_REQUEST, false, "중복된 데이터입니다."),
+    UNAUTHORIZED(HttpStatus.BAD_REQUEST, false, "권한이 없습니다"),
+    TEAM_NOT_EXIST(HttpStatus.BAD_REQUEST, false, "팀이 존재하지 않음"),
+    USER_NOT_TEAM_MEMBER(HttpStatus.BAD_REQUEST, false, "유저가 요청 대상 팀에 속해있지 않음"),
+    REFLECTION_STATUS_ERROR(HttpStatus.BAD_REQUEST, false, "현재 회고의 상태에 요청을 수행할 수 없음"),
+    NOT_INCLUDED_REFLECTION(HttpStatus.BAD_REQUEST, false, "회고가 팀에 속하지 않음"),
+    INPUT_VALUE_FORMAT_VALIDATION_ERROR(HttpStatus.BAD_REQUEST, false, "입력 값의 형식이 잘못됨"),
 
-    //team
-    GET_TEAM_INFO_SUCCESS(HttpStatus.OK, true, "팀 정보 가져오기 성공");
+    // JWT
+    NO_TOKEN(HttpStatus.OK, true, "TOKEN이 존재하지 않습니다"),
+    TOKEN_INVALID(HttpStatus.BAD_REQUEST, false, "TOKEN이 유효하지 않습니다"),
+    TOKEN_EXPIRED(HttpStatus.BAD_REQUEST, false, "TOKEN이 만료되었습니다"),
+
+    // auth
+    SIGN_IN_SUCCESS(HttpStatus.OK, true, "유저 로그인 성공"),
+    SIGN_UP_SUCCESS(HttpStatus.CREATED, true, "유저 회원가입과 로그인 성공"),
+    DELETE_USER_SUCCESS(HttpStatus.OK, true, "유저 정보 삭제 성공"),
+
+    // user
+    USER_JOIN_TEAM_SUCCESS(HttpStatus.OK, true, "유저 팀 합류 및 프로필 생성 성공"),
+    USER_UPDATE_PROFILE_SUCCESS(HttpStatus.OK, true, "유저 프로필 수정 성공"),
+    PROFILE_IMAGE_FORMAT_ERROR(HttpStatus.BAD_REQUEST, false, "이미지 파일만 업로드할 수 있습니다"),
+    GET_USER_TEAM_LIST_SUCCESS(HttpStatus.OK, true, "유저의 팀 목록 가져오기 성공"),
+    ALREADY_TEAM_MEMBER(HttpStatus.BAD_REQUEST, false, "이미 유저가 해당 팀에 합류된 상태"),
+    USER_TEAM_WITHDRAW(HttpStatus.BAD_REQUEST, false, "유저와 팀 정보가 잘못됨"),
+
+    // reflection
+    UPDATE_REFLECTION_DETAIL_SUCCESS(HttpStatus.OK, true, "회고 디테일 정보 추가 성공"),
+    REFLECTION_TIME_BEFORE(HttpStatus.BAD_REQUEST, false, "회고 시간이 현 시간 이전"),
+    DELETE_REFLECTION_DETAIL_SUCCESS(HttpStatus.OK, true, "회고 디테일 정보 삭제 성공"),
+    GET_REFLECTION_LIST_SUCCESS(HttpStatus.OK, true, "회고목록 조회 성공"),
+    END_REFLECTION_SUCCESS(HttpStatus.OK, true, "회고 종료 성공"),
+    GET_CURRENT_REFLECTION_SUCCESS(HttpStatus.OK, true, "현재 회고 정보 가져오기 성공"),
+
+    // team
+    GET_TEAM_NAME_SUCCESS(HttpStatus.OK, true, "팀 이름 가져오기 성공"),
+    GET_TEAM_INFO_SUCCESS(HttpStatus.OK, true, "팀 정보 가져오기 성공"),
+    INVALID_INVITATION_CODE(HttpStatus.BAD_REQUEST, false, "초대코드가 잘못 됨"),
+    WITHDRAW_TEAM_SUCCESS(HttpStatus.OK, true, "유저 팀 탈퇴 성공"),
+    GET_TEAM_MEMBER_LIST_SUCCESS(HttpStatus.OK, true, "팀의 멤버 목록 가져오기 성공"),
+    EDIT_TEAM_NAME_SUCCESS(HttpStatus.OK, true, "팀 이름 수정 성공"),
+    CREATE_JOIN_TEAM_SUCCESS(HttpStatus.CREATED, true, "팀 생성 및 팀 합류 완료"),
+
+    // feedback
+    CREATE_FEEDBACK_SUCCESS(HttpStatus.CREATED, true, "피드백 생성하기 성공"),
+    NOT_INCLUDED_USER(HttpStatus.BAD_REQUEST, false, "피드백을 받는 유저가 현재 팀에 속하지 않음"),
+    FEEDBACK_TYPE_ERROR(HttpStatus.BAD_REQUEST, false, "피드백 타입 오류"),
+    FEEDBACK_MYSELF_ERROR(HttpStatus.BAD_REQUEST, false, "본인에게는 피드백을 작성할 수 없음"),
+    GET_FEEDBACK_SUCCESS(HttpStatus.OK, true, "피드백 조회 성공"),
+    GET_RECENT_FEEDBACK_SUCCESS(HttpStatus.OK, true, "최근 피드백 조회 성공"),
+    GET_FEEDBACK_LIST_TO_SPECIFIC_MEMBER_SUCCESS(HttpStatus.OK, true, "특정 멤버에게 작성한 피드백 목록 가져오기 성공"),
+    DELETE_FEEDBACK_SUCCESS(HttpStatus.OK, true, "피드백 삭제 성공"),
+    DELETE_FEEDBACK_NOT_EXIST(HttpStatus.BAD_REQUEST, false, "삭제할 피드백 정보가 없습니다"),
+    DELETE_FEEDBACK_OTHERS_ERROR(HttpStatus.BAD_REQUEST, false, "타 유저가 작성한 피드백에 대한 삭제 권한 없음"),
+    UPDATE_FEEDBACK_SUCCESS(HttpStatus.CREATED, true, "피드백 수정 성공"),
+    UPDATE_FEEDBACK_OTHERS_ERROR(HttpStatus.BAD_REQUEST, false, "타 유저가 작성한 피드백에 대한 수정 권한 없음"),
+    NOT_INCLUDED_FEEDBACK(HttpStatus.BAD_REQUEST, false, "피드백이 회고에 속하지 않음");
 
     private final HttpStatus httpStatus;
     private final Boolean success;

--- a/src/main/java/maddori/keygo/common/response/SuccessResponse.java
+++ b/src/main/java/maddori/keygo/common/response/SuccessResponse.java
@@ -1,0 +1,30 @@
+package maddori.keygo.common.response;
+
+import lombok.Builder;
+import lombok.Data;
+import lombok.Getter;
+import lombok.Setter;
+import lombok.experimental.SuperBuilder;
+import org.springframework.http.HttpEntity;
+import org.springframework.http.HttpStatusCode;
+import org.springframework.http.ResponseEntity;
+import org.springframework.lang.Nullable;
+
+@SuperBuilder
+@Getter
+@Setter
+public class SuccessResponse extends BasicResponse {
+    @Nullable
+    private Object data;
+
+    public static ResponseEntity<BasicResponse> toResponseEntity(ResponseCode responseCode, @Nullable Object data) {
+        return ResponseEntity
+                .status(responseCode.getHttpStatus())
+                .body(SuccessResponse.builder()
+                        .success(responseCode.getSuccess())
+                        .message(responseCode.getMessage())
+                        .data(data)
+                        .build()
+                );
+    }
+}

--- a/src/main/java/maddori/keygo/common/response/SuccessResponse.java
+++ b/src/main/java/maddori/keygo/common/response/SuccessResponse.java
@@ -15,7 +15,7 @@ import org.springframework.lang.Nullable;
 @Setter
 public class SuccessResponse extends BasicResponse {
     @Nullable
-    private Object data;
+    private Object detail;
 
     public static ResponseEntity<BasicResponse> toResponseEntity(ResponseCode responseCode, @Nullable Object data) {
         return ResponseEntity
@@ -23,7 +23,7 @@ public class SuccessResponse extends BasicResponse {
                 .body(SuccessResponse.builder()
                         .success(responseCode.getSuccess())
                         .message(responseCode.getMessage())
-                        .data(data)
+                        .detail(data)
                         .build()
                 );
     }

--- a/src/main/java/maddori/keygo/controller/TeamController.java
+++ b/src/main/java/maddori/keygo/controller/TeamController.java
@@ -2,6 +2,7 @@ package maddori.keygo.controller;
 
 import jakarta.persistence.Basic;
 import lombok.RequiredArgsConstructor;
+import maddori.keygo.common.exception.CustomException;
 import maddori.keygo.common.response.BasicResponse;
 import maddori.keygo.common.response.SuccessResponse;
 import maddori.keygo.service.TeamService;
@@ -21,7 +22,7 @@ public class TeamController {
     @GetMapping("/{teamId}")
     public ResponseEntity<? extends BasicResponse> getCertainTeamDetail(@PathVariable("teamId") String teamId) {
         TeamResponseDto teamResponseDto = teamService.getCertainTeam(teamId);
-
+        System.out.println("here");
         return SuccessResponse.toResponseEntity(GET_TEAM_INFO_SUCCESS, teamResponseDto);
     }
 }

--- a/src/main/java/maddori/keygo/controller/TeamController.java
+++ b/src/main/java/maddori/keygo/controller/TeamController.java
@@ -1,11 +1,15 @@
 package maddori.keygo.controller;
 
+import jakarta.persistence.Basic;
 import lombok.RequiredArgsConstructor;
+import maddori.keygo.common.response.BasicResponse;
+import maddori.keygo.common.response.SuccessResponse;
 import maddori.keygo.service.TeamService;
 import maddori.keygo.dto.team.TeamResponseDto;
-import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
+
+import static maddori.keygo.common.response.ResponseCode.*;
 
 @RestController
 @RequiredArgsConstructor
@@ -15,9 +19,9 @@ public class TeamController {
     private final TeamService teamService;
 
     @GetMapping("/{teamId}")
-    public ResponseEntity<TeamResponseDto> getCertainTeamDetail(@PathVariable("teamId") String teamId) {
+    public ResponseEntity<? extends BasicResponse> getCertainTeamDetail(@PathVariable("teamId") String teamId) {
         TeamResponseDto teamResponseDto = teamService.getCertainTeam(teamId);
 
-        return new ResponseEntity<>(teamResponseDto, HttpStatus.OK);
+        return SuccessResponse.toResponseEntity(GET_TEAM_INFO_SUCCESS, teamResponseDto);
     }
 }

--- a/src/main/java/maddori/keygo/service/TeamService.java
+++ b/src/main/java/maddori/keygo/service/TeamService.java
@@ -2,11 +2,15 @@ package maddori.keygo.service;
 
 import jakarta.persistence.EntityNotFoundException;
 import lombok.RequiredArgsConstructor;
+import maddori.keygo.common.exception.CustomException;
+import maddori.keygo.common.response.ResponseCode;
 import maddori.keygo.dto.team.TeamResponseDto;
 import maddori.keygo.domain.entity.Team;
 import maddori.keygo.repository.TeamRepository;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
+
+import static maddori.keygo.common.response.ResponseCode.*;
 
 @Service
 @RequiredArgsConstructor
@@ -15,7 +19,7 @@ public class TeamService {
     private final TeamRepository teamRepository;
     @Transactional(readOnly = true)
     public TeamResponseDto getCertainTeam(String teamId) {
-         Team team = teamRepository.findById(Long.valueOf(teamId)).orElseThrow(() -> new EntityNotFoundException("유저가 요청 대상 팀에 속해 있지 않음."));
+         Team team = teamRepository.findById(Long.valueOf(teamId)).orElseThrow(() -> new CustomException(TEAM_NOT_EXIST));
          TeamResponseDto response = TeamResponseDto.
                  builder().id(team.getId())
                             .teamName(team.getTeamName())


### PR DESCRIPTION
## 📝 Summary
<!-- 해당 PR의 주요 내용을 적어주세요 -->
- 아래에 맞게 Response 형식 구현
  ```json
    {
	    "success" : "true",
	    "message" : "message",
	    "detail" : "detail"
    }
  ```
  ```json
  {
	  "success" : "false",
	  "message" : "message"
  }
  ```
- CustomException class 구현, 핸들러 추가

## 👩‍💻 Contents
<!-- 작업 내용을 적어주세요 -->
- response 형식 구현
  BasicResponse 추상화 클래스를 만든 후, 이를 상속하는 SuccessResponse와 FailResponse 클래스를 구현하였습니다. 각 클래스의 toResponseEntity 메서드를 통해 body가 custom된 ResponseEntity를 반환할 수 있게 됩니다.

- ResponseCode enum 구현
  위 response format에 들어갈 내용을 enum화하여 아래와 같이 사용할 수 있도록 구현하였습니다.
  `SuccessResponse.toResponseEntity(ResponseCode.GET_TEAM_INFO_SUCCESS, teamResponseDto); `

- CustomException 구현
   ResponseCode를 가지는 CustomException 클래스를 선언하였고, CustomException이 발생하였을 때 FailResponse 형식에 맞추어 ResponseEntity가 반환되도록 구현하였습니다. 아래와 같이 사용 가능합니다.
  `new CustomException(ResponseCode.TEAM_NOT_EXIST)`

## 📝 Review Note
<!-- PR과정에서 든 생각이나 개선할 내용이 있다면 적어주세요. -->
Spring에서 형식 validation을 어떻게 진행하는지, 에러는 어떻게 반환되는지에 대한 공부를 아직 못해서 형식 관련 에러`(ex. 팀 이름 10자 이내)`에 대한 ResponseCode는 추가하지 않은 상태입니다.
추후 형식에 관한 에러 핸들링도 추가해야 할 것 같습니다!!

## 📣 Related Issue
<!-- 관련 이슈를 적어주세요. -->
- close #1 


## 📬 Reference
<!-- 참고한 코드의 출처를 작성해주세요 -->
https://velog.io/@dot2__/SpringBoot-Custom-Exception-Response-만들기