### PR TITLE
[FEAT] getCertainTeamName api 구현

### DIFF
--- a/src/main/java/maddori/keygo/controller/TeamController.java
+++ b/src/main/java/maddori/keygo/controller/TeamController.java
@@ -5,6 +5,7 @@ import lombok.RequiredArgsConstructor;
 import maddori.keygo.common.exception.CustomException;
 import maddori.keygo.common.response.BasicResponse;
 import maddori.keygo.common.response.SuccessResponse;
+import maddori.keygo.dto.team.TeamNameResponseDto;
 import maddori.keygo.service.TeamService;
 import maddori.keygo.dto.team.TeamResponseDto;
 import org.springframework.http.ResponseEntity;
@@ -22,7 +23,12 @@ public class TeamController {
     @GetMapping("/{teamId}")
     public ResponseEntity<? extends BasicResponse> getCertainTeamDetail(@PathVariable("teamId") String teamId) {
         TeamResponseDto teamResponseDto = teamService.getCertainTeam(teamId);
-        System.out.println("here");
         return SuccessResponse.toResponseEntity(GET_TEAM_INFO_SUCCESS, teamResponseDto);
+    }
+
+    @GetMapping("")
+    public ResponseEntity<? extends BasicResponse> getCertainTeamName(@RequestParam("invitation_code") String invitationCode) {
+        TeamNameResponseDto teamNameResponseDto = teamService.getCertainTeamName(invitationCode);
+        return SuccessResponse.toResponseEntity(GET_TEAM_INFO_SUCCESS, teamNameResponseDto);
     }
 }

--- a/src/main/java/maddori/keygo/dto/team/TeamNameResponseDto.java
+++ b/src/main/java/maddori/keygo/dto/team/TeamNameResponseDto.java
@@ -1,0 +1,17 @@
+package maddori.keygo.dto.team;
+
+import lombok.Builder;
+import lombok.Data;
+
+@Data
+public class TeamNameResponseDto {
+
+    private Long id;
+    private String team_name;
+
+    @Builder
+    public TeamNameResponseDto(Long id, String teamName) {
+        this.id = id;
+        this.team_name = teamName;
+    }
+}

--- a/src/main/java/maddori/keygo/repository/TeamRepository.java
+++ b/src/main/java/maddori/keygo/repository/TeamRepository.java
@@ -6,4 +6,5 @@ import org.springframework.data.jpa.repository.JpaRepository;
 import java.util.Optional;
 
 public interface TeamRepository extends JpaRepository<Team, Long> {
+    Optional<Team> findByInvitationCode(String invitationCode);
 }

--- a/src/main/java/maddori/keygo/service/TeamService.java
+++ b/src/main/java/maddori/keygo/service/TeamService.java
@@ -4,6 +4,7 @@ import jakarta.persistence.EntityNotFoundException;
 import lombok.RequiredArgsConstructor;
 import maddori.keygo.common.exception.CustomException;
 import maddori.keygo.common.response.ResponseCode;
+import maddori.keygo.dto.team.TeamNameResponseDto;
 import maddori.keygo.dto.team.TeamResponseDto;
 import maddori.keygo.domain.entity.Team;
 import maddori.keygo.repository.TeamRepository;
@@ -28,4 +29,13 @@ public class TeamService {
          return response;
     }
 
+    @Transactional(readOnly = true)
+    public TeamNameResponseDto getCertainTeamName(String invitationCode) {
+        Team team = teamRepository.findByInvitationCode(invitationCode).orElseThrow(() -> new CustomException(INVALID_INVITATION_CODE));
+        TeamNameResponseDto response = TeamNameResponseDto.
+                builder().id(team.getId())
+                        .teamName(team.getTeamName())
+                        .build();
+        return response;
+    }
 }


### PR DESCRIPTION
## 📝 Summary
<!-- 해당 PR의 주요 내용을 적어주세요 -->
getCertainTeamName api 구현
- `api/v2/teams?invitation_code={invitation_code}`
- 초대 코드가 일치하는 팀의 id, team_name을 반환

## 👩‍💻 Contents
<!-- 작업 내용을 적어주세요 -->
- controller, service에 getCertainTeamName api 로직 추가
- TeamRepository에 `findByInvitationCode` 메서드 추가
   team 테이블에서 invitation_code가 일치하는 필드를 반환함
- TeamNameResponseDto 추가 (아래 예시)
  ```json
  "id": 1,
  "team_name": "맛쟁이사과처럼"
  ```
- 초대코드 일치하지 않을시 `"초대 코드가 잘못됨"` 에러 반환

## 📝 Review Note
<!-- PR과정에서 든 생각이나 개선할 내용이 있다면 적어주세요. -->


## 📣 Related Issue
<!-- 관련 이슈를 적어주세요. -->
- close #3 


## 📬 Reference
<!-- 참고한 코드의 출처를 작성해주세요 -->
