### PR TITLE
[FEAT] 회고 목록 조회 API 구현

### DIFF
--- a/src/main/java/maddori/keygo/common/response/ResponseCode.java
+++ b/src/main/java/maddori/keygo/common/response/ResponseCode.java
@@ -43,7 +43,7 @@ public enum ResponseCode {
     REFLECTION_TIME_BEFORE(HttpStatus.BAD_REQUEST, false, "회고 시간이 현 시간 이전"),
     DELETE_REFLECTION_DETAIL_SUCCESS(HttpStatus.OK, true, "회고 디테일 정보 삭제 성공"),
     GET_REFLECTION_LIST_SUCCESS(HttpStatus.OK, true, "회고목록 조회 성공"),
-    GET_REFLECTION_LIST_FAIL(HttpStatus.OK, true, "회고목록 조회 실패"),
+    GET_REFLECTION_LIST_FAIL(HttpStatus.BAD_REQUEST, true, "회고목록 조회 실패"),
 
     END_REFLECTION_SUCCESS(HttpStatus.OK, true, "회고 종료 성공"),
     GET_CURRENT_REFLECTION_SUCCESS(HttpStatus.OK, true, "현재 회고 정보 가져오기 성공"),

--- a/src/main/java/maddori/keygo/common/response/ResponseCode.java
+++ b/src/main/java/maddori/keygo/common/response/ResponseCode.java
@@ -43,7 +43,7 @@ public enum ResponseCode {
     REFLECTION_TIME_BEFORE(HttpStatus.BAD_REQUEST, false, "회고 시간이 현 시간 이전"),
     DELETE_REFLECTION_DETAIL_SUCCESS(HttpStatus.OK, true, "회고 디테일 정보 삭제 성공"),
     GET_REFLECTION_LIST_SUCCESS(HttpStatus.OK, true, "회고목록 조회 성공"),
-    GET_REFLECTION_LIST_FAIL(HttpStatus.BAD_REQUEST, true, "회고목록 조회 실패"),
+    GET_REFLECTION_LIST_FAIL(HttpStatus.BAD_REQUEST, false, "회고목록 조회 실패"),
 
     END_REFLECTION_SUCCESS(HttpStatus.OK, true, "회고 종료 성공"),
     GET_CURRENT_REFLECTION_SUCCESS(HttpStatus.OK, true, "현재 회고 정보 가져오기 성공"),

--- a/src/main/java/maddori/keygo/dto/reflection/ReflectionResponseDto.java
+++ b/src/main/java/maddori/keygo/dto/reflection/ReflectionResponseDto.java
@@ -1,5 +1,6 @@
 package maddori.keygo.dto.reflection;
 
+import com.fasterxml.jackson.annotation.JsonProperty;
 import lombok.Builder;
 import lombok.Data;
 import maddori.keygo.domain.ReflectionState;
@@ -10,9 +11,13 @@ import java.time.LocalDateTime;
 public class ReflectionResponseDto {
 
     private Long id;
+
+    @JsonProperty("reflection_name")
     private String reflectionName;
     private LocalDateTime date;
     private ReflectionState state;
+
+    @JsonProperty("team_id")
     private Long teamId;
 
     @Builder

--- a/src/main/java/maddori/keygo/service/ReflectionService.java
+++ b/src/main/java/maddori/keygo/service/ReflectionService.java
@@ -20,7 +20,7 @@ public class ReflectionService {
     @Transactional(readOnly = true)
     public List<ReflectionResponseDto> getPastReflectionList(Long teamId) {
 
-        List<Reflection> reflectionList = reflectionRepository.findReflectionsByStateAndTeam_Id( ReflectionState.Done, teamId)
+        List<Reflection> reflectionList = reflectionRepository.findReflectionsByStateAndTeam_Id( ReflectionState.Done, teamId);
         List<ReflectionResponseDto> result = reflectionList.stream()
                 .map(r -> ReflectionResponseDto.builder()
                         .id(r.getId())


### PR DESCRIPTION
## 📝 Summary
<!-- 해당 PR의 주요 내용을 적어주세요 -->
getPastReflection api 구현
- `api/v2/teams/{teamId}/reflections`
- teamId에 해당하는 state가 done인 회고 정보 가져오기

## 👩‍💻 Contents
<!-- 작업 내용을 적어주세요 -->
- controller, service getPastReflection api 로직 추가
- ReflectionRepository에 메서드 추가
- ReflectionResponseDto 추가

## 📝 Review Note
<!-- PR과정에서 든 생각이나 개선할 내용이 있다면 적어주세요. -->


## 📣 Related Issue
<!-- 관련 이슈를 적어주세요. -->
- close #4 

