### PR TITLE
[FEAT] 피드백 삭제 API 구현

### DIFF
--- a/src/main/java/maddori/keygo/common/response/ResponseCode.java
+++ b/src/main/java/maddori/keygo/common/response/ResponseCode.java
@@ -43,6 +43,8 @@ public enum ResponseCode {
     REFLECTION_TIME_BEFORE(HttpStatus.BAD_REQUEST, false, "회고 시간이 현 시간 이전"),
     DELETE_REFLECTION_DETAIL_SUCCESS(HttpStatus.OK, true, "회고 디테일 정보 삭제 성공"),
     GET_REFLECTION_LIST_SUCCESS(HttpStatus.OK, true, "회고목록 조회 성공"),
+    GET_REFLECTION_LIST_FAIL(HttpStatus.OK, true, "회고목록 조회 실패"),
+
     END_REFLECTION_SUCCESS(HttpStatus.OK, true, "회고 종료 성공"),
     GET_CURRENT_REFLECTION_SUCCESS(HttpStatus.OK, true, "현재 회고 정보 가져오기 성공"),
 

--- a/src/main/java/maddori/keygo/common/response/ResponseCode.java
+++ b/src/main/java/maddori/keygo/common/response/ResponseCode.java
@@ -43,7 +43,7 @@ public enum ResponseCode {
     REFLECTION_TIME_BEFORE(HttpStatus.BAD_REQUEST, false, "회고 시간이 현 시간 이전"),
     DELETE_REFLECTION_DETAIL_SUCCESS(HttpStatus.OK, true, "회고 디테일 정보 삭제 성공"),
     GET_REFLECTION_LIST_SUCCESS(HttpStatus.OK, true, "회고목록 조회 성공"),
-    GET_REFLECTION_LIST_FAIL(HttpStatus.OK, true, "회고목록 조회 실패"),
+    GET_REFLECTION_LIST_FAIL(HttpStatus.BAD_REQUEST, true, "회고목록 조회 실패"),
 
     END_REFLECTION_SUCCESS(HttpStatus.OK, true, "회고 종료 성공"),
     GET_CURRENT_REFLECTION_SUCCESS(HttpStatus.OK, true, "현재 회고 정보 가져오기 성공"),
@@ -71,6 +71,7 @@ public enum ResponseCode {
     UPDATE_FEEDBACK_SUCCESS(HttpStatus.CREATED, true, "피드백 수정 성공"),
     UPDATE_FEEDBACK_OTHERS_ERROR(HttpStatus.BAD_REQUEST, false, "타 유저가 작성한 피드백에 대한 수정 권한 없음"),
     NOT_INCLUDED_FEEDBACK(HttpStatus.BAD_REQUEST, false, "피드백이 회고에 속하지 않음");
+
 
     // 입력값 형식 관련
 

--- a/src/main/java/maddori/keygo/controller/FeedbackController.java
+++ b/src/main/java/maddori/keygo/controller/FeedbackController.java
@@ -1,2 +1,35 @@
-package maddori.keygo.controller;public class FeedbackController {
+package maddori.keygo.controller;
+
+import lombok.RequiredArgsConstructor;
+import maddori.keygo.common.response.BasicResponse;
+import maddori.keygo.common.response.FailResponse;
+import maddori.keygo.common.response.ResponseCode;
+import maddori.keygo.common.response.SuccessResponse;
+import maddori.keygo.service.FeedbackService;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.DeleteMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("/api/v2/teams")
+@RequiredArgsConstructor
+public class FeedbackController {
+
+    private final FeedbackService feedbackService;
+
+    @DeleteMapping("/{teamId}/reflections/{reflectionId}/feedbacks/{feedbackId}}")
+    public ResponseEntity<? extends BasicResponse> deleteFeedback(
+            @PathVariable("teamId") Long teamId,
+            @PathVariable("reflectionId") Long reflectionId,
+            @PathVariable("feedbackId") Long feedbackId
+    ) {
+        try {
+            feedbackService.delete(teamId, reflectionId, feedbackId);
+            return SuccessResponse.toResponseEntity(ResponseCode.DELETE_FEEDBACK_SUCCESS, null);
+        } catch (RuntimeException e) {
+            return FailResponse.toResponseEntity(ResponseCode.DELETE_FEEDBACK_NOT_EXIST);
+        }
+    }
 }

--- a/src/main/java/maddori/keygo/controller/FeedbackController.java
+++ b/src/main/java/maddori/keygo/controller/FeedbackController.java
@@ -1,0 +1,2 @@
+package maddori.keygo.controller;public class FeedbackController {
+}

--- a/src/main/java/maddori/keygo/controller/FeedbackController.java
+++ b/src/main/java/maddori/keygo/controller/FeedbackController.java
@@ -19,7 +19,7 @@ public class FeedbackController {
 
     private final FeedbackService feedbackService;
 
-    @DeleteMapping("/{teamId}/reflections/{reflectionId}/feedbacks/{feedbackId}}")
+    @DeleteMapping("/{teamId}/reflections/{reflectionId}/feedbacks/{feedbackId}")
     public ResponseEntity<? extends BasicResponse> deleteFeedback(
             @PathVariable("teamId") Long teamId,
             @PathVariable("reflectionId") Long reflectionId,

--- a/src/main/java/maddori/keygo/controller/ReflectionController.java
+++ b/src/main/java/maddori/keygo/controller/ReflectionController.java
@@ -1,5 +1,8 @@
 package maddori.keygo.controller;
 
+import com.nimbusds.jose.shaded.gson.Gson;
+import lombok.Builder;
+import lombok.Data;
 import lombok.RequiredArgsConstructor;
 import maddori.keygo.common.response.BasicResponse;
 import maddori.keygo.common.response.ResponseCode;
@@ -23,6 +26,17 @@ public class ReflectionController {
             @PathVariable("teamId") Long teamId
     ) {
         List<ReflectionResponseDto> reflectionResponseDtoList = reflectionService.getPastReflectionList(teamId);
-        return SuccessResponse.toResponseEntity(ResponseCode.GET_REFLECTION_LIST_SUCCESS, reflectionResponseDtoList);
+        ReflectionListResponseDto responseData = ReflectionListResponseDto.builder()
+                .reflection(reflectionResponseDtoList)
+                .build();
+
+        return SuccessResponse.toResponseEntity(ResponseCode.GET_REFLECTION_LIST_SUCCESS, responseData);
+    }
+
+    @Data
+    @Builder
+    public static class ReflectionListResponseDto {
+        private List<ReflectionResponseDto> reflection;
     }
 }
+

--- a/src/main/java/maddori/keygo/controller/ReflectionController.java
+++ b/src/main/java/maddori/keygo/controller/ReflectionController.java
@@ -5,6 +5,7 @@ import lombok.Builder;
 import lombok.Data;
 import lombok.RequiredArgsConstructor;
 import maddori.keygo.common.response.BasicResponse;
+import maddori.keygo.common.response.FailResponse;
 import maddori.keygo.common.response.ResponseCode;
 import maddori.keygo.common.response.SuccessResponse;
 import maddori.keygo.dto.reflection.ReflectionResponseDto;
@@ -25,12 +26,18 @@ public class ReflectionController {
     public ResponseEntity<? extends BasicResponse> getPastReflectionList(
             @PathVariable("teamId") Long teamId
     ) {
-        List<ReflectionResponseDto> reflectionResponseDtoList = reflectionService.getPastReflectionList(teamId);
-        ReflectionListResponseDto responseData = ReflectionListResponseDto.builder()
-                .reflection(reflectionResponseDtoList)
-                .build();
+        try {
+            List<ReflectionResponseDto> reflectionResponseDtoList = reflectionService.getPastReflectionList(teamId);
+            ReflectionListResponseDto responseData = ReflectionListResponseDto.builder()
+                    .reflection(reflectionResponseDtoList)
+                    .build();
 
-        return SuccessResponse.toResponseEntity(ResponseCode.GET_REFLECTION_LIST_SUCCESS, responseData);
+            return SuccessResponse.toResponseEntity(ResponseCode.GET_REFLECTION_LIST_SUCCESS, responseData);
+        }
+        catch (RuntimeException e) {
+            return FailResponse.toResponseEntity(ResponseCode.GET_REFLECTION_LIST_FAIL);
+        }
+
     }
 
     @Data

--- a/src/main/java/maddori/keygo/controller/ReflectionController.java
+++ b/src/main/java/maddori/keygo/controller/ReflectionController.java
@@ -1,0 +1,28 @@
+package maddori.keygo.controller;
+
+import lombok.RequiredArgsConstructor;
+import maddori.keygo.common.response.BasicResponse;
+import maddori.keygo.common.response.ResponseCode;
+import maddori.keygo.common.response.SuccessResponse;
+import maddori.keygo.dto.reflection.ReflectionResponseDto;
+import maddori.keygo.service.ReflectionService;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.List;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/v2/teams")
+public class ReflectionController {
+
+    private final ReflectionService reflectionService;
+
+    @GetMapping("/{teamId}/reflections")
+    public ResponseEntity<? extends BasicResponse> getPastReflectionList(
+            @PathVariable("teamId") Long teamId
+    ) {
+        List<ReflectionResponseDto> reflectionResponseDtoList = reflectionService.getPastReflectionList(teamId);
+        return SuccessResponse.toResponseEntity(ResponseCode.GET_REFLECTION_LIST_SUCCESS, reflectionResponseDtoList);
+    }
+}

--- a/src/main/java/maddori/keygo/dto/reflection/ReflectionResponseDto.java
+++ b/src/main/java/maddori/keygo/dto/reflection/ReflectionResponseDto.java
@@ -1,0 +1,26 @@
+package maddori.keygo.dto.reflection;
+
+import lombok.Builder;
+import lombok.Data;
+import maddori.keygo.domain.ReflectionState;
+
+import java.time.LocalDateTime;
+
+@Data
+public class ReflectionResponseDto {
+
+    private Long id;
+    private String reflectionName;
+    private LocalDateTime date;
+    private ReflectionState state;
+    private Long teamId;
+
+    @Builder
+    public ReflectionResponseDto(Long id, String reflectionName, LocalDateTime date, ReflectionState state, Long teamId) {
+        this.id = id;
+        this.reflectionName = reflectionName;
+        this.date = date;
+        this.state = state;
+        this.teamId = teamId;
+    }
+}

--- a/src/main/java/maddori/keygo/repository/FeedbackRepository.java
+++ b/src/main/java/maddori/keygo/repository/FeedbackRepository.java
@@ -4,4 +4,6 @@ import maddori.keygo.domain.entity.Feedback;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 public interface FeedbackRepository extends JpaRepository<Feedback, Long> {
+
+    public void deleteById(Long id);
 }

--- a/src/main/java/maddori/keygo/repository/ReflectionRepository.java
+++ b/src/main/java/maddori/keygo/repository/ReflectionRepository.java
@@ -3,5 +3,9 @@ package maddori.keygo.repository;
 import maddori.keygo.domain.entity.Reflection;
 import org.springframework.data.jpa.repository.JpaRepository;
 
+import java.util.List;
+
 public interface ReflectionRepository extends JpaRepository<Reflection, Long> {
+
+    public List<Reflection> findReflectionsByTeam_Id(Long teamId);
 }

--- a/src/main/java/maddori/keygo/repository/ReflectionRepository.java
+++ b/src/main/java/maddori/keygo/repository/ReflectionRepository.java
@@ -1,5 +1,6 @@
 package maddori.keygo.repository;
 
+import maddori.keygo.domain.ReflectionState;
 import maddori.keygo.domain.entity.Reflection;
 import org.springframework.data.jpa.repository.JpaRepository;
 
@@ -7,5 +8,5 @@ import java.util.List;
 
 public interface ReflectionRepository extends JpaRepository<Reflection, Long> {
 
-    public List<Reflection> findReflectionsByTeam_Id(Long teamId);
+    public List<Reflection> findReflectionsByStateAndTeam_Id(ReflectionState state, Long teamId);
 }

--- a/src/main/java/maddori/keygo/service/FeedbackService.java
+++ b/src/main/java/maddori/keygo/service/FeedbackService.java
@@ -1,0 +1,2 @@
+package maddori.keygo.service;public class FeedbackService {
+}

--- a/src/main/java/maddori/keygo/service/FeedbackService.java
+++ b/src/main/java/maddori/keygo/service/FeedbackService.java
@@ -1,2 +1,18 @@
-package maddori.keygo.service;public class FeedbackService {
+package maddori.keygo.service;
+
+import lombok.RequiredArgsConstructor;
+import maddori.keygo.repository.FeedbackRepository;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class FeedbackService {
+    private final FeedbackRepository feedbackRepository;
+
+    public void delete(Long TeamId, Long reflectionId, Long feedbackId) {
+        feedbackRepository.deleteById(feedbackId);
+    }
+
 }
+
+

--- a/src/main/java/maddori/keygo/service/ReflectionService.java
+++ b/src/main/java/maddori/keygo/service/ReflectionService.java
@@ -19,7 +19,8 @@ public class ReflectionService {
 
     @Transactional(readOnly = true)
     public List<ReflectionResponseDto> getPastReflectionList(Long teamId) {
-        List<Reflection> reflectionList = reflectionRepository.findReflectionsByStateAndTeam_Id( ReflectionState.Done, teamId);
+
+        List<Reflection> reflectionList = reflectionRepository.findReflectionsByStateAndTeam_Id( ReflectionState.Done, teamId)
         List<ReflectionResponseDto> result = reflectionList.stream()
                 .map(r -> ReflectionResponseDto.builder()
                         .id(r.getId())

--- a/src/main/java/maddori/keygo/service/ReflectionService.java
+++ b/src/main/java/maddori/keygo/service/ReflectionService.java
@@ -1,6 +1,7 @@
 package maddori.keygo.service;
 
 import lombok.RequiredArgsConstructor;
+import maddori.keygo.domain.ReflectionState;
 import maddori.keygo.domain.entity.Reflection;
 import maddori.keygo.dto.reflection.ReflectionResponseDto;
 import maddori.keygo.repository.ReflectionRepository;
@@ -18,7 +19,7 @@ public class ReflectionService {
 
     @Transactional(readOnly = true)
     public List<ReflectionResponseDto> getPastReflectionList(Long teamId) {
-        List<Reflection> reflectionList = reflectionRepository.findReflectionsByTeam_Id(teamId);
+        List<Reflection> reflectionList = reflectionRepository.findReflectionsByStateAndTeam_Id( ReflectionState.Done, teamId);
         List<ReflectionResponseDto> result = reflectionList.stream()
                 .map(r -> ReflectionResponseDto.builder()
                         .id(r.getId())

--- a/src/main/java/maddori/keygo/service/ReflectionService.java
+++ b/src/main/java/maddori/keygo/service/ReflectionService.java
@@ -20,7 +20,7 @@ public class ReflectionService {
     @Transactional(readOnly = true)
     public List<ReflectionResponseDto> getPastReflectionList(Long teamId) {
 
-        List<Reflection> reflectionList = reflectionRepository.findReflectionsByStateAndTeam_Id( ReflectionState.Done, teamId)
+        List<Reflection> reflectionList = reflectionRepository.findReflectionsByStateAndTeam_Id( ReflectionState.Done, teamId);
         List<ReflectionResponseDto> result = reflectionList.stream()
                 .map(r -> ReflectionResponseDto.builder()
                         .id(r.getId())

--- a/src/main/java/maddori/keygo/service/ReflectionService.java
+++ b/src/main/java/maddori/keygo/service/ReflectionService.java
@@ -1,0 +1,35 @@
+package maddori.keygo.service;
+
+import lombok.RequiredArgsConstructor;
+import maddori.keygo.domain.entity.Reflection;
+import maddori.keygo.dto.reflection.ReflectionResponseDto;
+import maddori.keygo.repository.ReflectionRepository;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+import java.util.stream.Collectors;
+
+@Service
+@RequiredArgsConstructor
+public class ReflectionService {
+
+    private final ReflectionRepository reflectionRepository;
+
+    @Transactional(readOnly = true)
+    public List<ReflectionResponseDto> getPastReflectionList(Long teamId) {
+        List<Reflection> reflectionList = reflectionRepository.findReflectionsByTeam_Id(teamId);
+        List<ReflectionResponseDto> result = reflectionList.stream()
+                .map(r -> ReflectionResponseDto.builder()
+                        .id(r.getId())
+                        .reflectionName(r.getReflectionName())
+                        .date(r.getDate())
+                        .state(r.getState())
+                        .teamId(r.getTeam().getId())
+                        .build())
+                .collect(Collectors.toList());
+
+        return result;
+    }
+
+}

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -15,6 +15,9 @@ spring:
       path: /h2-console
       settings:
         web-allow-others: true
+  mvc:
+    pathmatch:
+      matching-strategy: ant_path_matcher
   jpa:
     hibernate:
       ddl-auto: create

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -21,4 +21,4 @@ spring:
     properties:
       hibernate:
         show_sql: true
-        format_sql:
+        format_sql: true


### PR DESCRIPTION
## 📝 Summary
<!-- 해당 PR의 주요 내용을 적어주세요 -->
deleteFeedback api 구현
- `api/v2/teams/{teamId}/reflections/{reflectionId}/feedbacks/{feedbackId}`
- 피드백 id에 해당하는 

## 👩‍💻 Contents
<!-- 작업 내용을 적어주세요 -->
- controller, service에 deleteFeedback api 로직 추가
- FeedbackRepository에 `deleteFeedback` 메서드 추가
   team 테이블에서 invitation_code가 일치하는 필드를 반환함

## 📝 Review Note
<!-- PR과정에서 든 생각이나 개선할 내용이 있다면 적어주세요. -->
- API에 해당 user가 feedback을 삭제할 권한이 있는지 검증하는 로직이 추가 되어야 함. 

## 📣 Related Issue
<!-- 관련 이슈를 적어주세요. -->
- close #5 


