### PR TITLE
[FEAT] NoDetailSuccessResponse 구현(#10)

### DIFF
--- a/src/main/java/maddori/keygo/common/response/NoDetailSuccessResponse.java
+++ b/src/main/java/maddori/keygo/common/response/NoDetailSuccessResponse.java
@@ -1,29 +1,21 @@
 package maddori.keygo.common.response;
 
-import lombok.Builder;
-import lombok.Data;
 import lombok.Getter;
 import lombok.Setter;
 import lombok.experimental.SuperBuilder;
-import org.springframework.http.HttpEntity;
-import org.springframework.http.HttpStatusCode;
 import org.springframework.http.ResponseEntity;
-import org.springframework.lang.Nullable;
 
 @SuperBuilder
 @Getter
 @Setter
-public class SuccessResponse extends BasicResponse {
+public class NoDetailSuccessResponse extends BasicResponse {
 
-    private Object detail;
-
-    public static ResponseEntity<BasicResponse> toResponseEntity(ResponseCode responseCode, Object data) {
+    public static ResponseEntity<BasicResponse> toResponseEntity(ResponseCode responseCode) {
         return ResponseEntity
                 .status(responseCode.getHttpStatus())
-                .body(SuccessResponse.builder()
+                .body(FailResponse.builder()
                         .success(responseCode.getSuccess())
                         .message(responseCode.getMessage())
-                        .detail(data)
                         .build()
                 );
     }

--- a/src/main/java/maddori/keygo/controller/TeamController.java
+++ b/src/main/java/maddori/keygo/controller/TeamController.java
@@ -4,6 +4,7 @@ import jakarta.persistence.Basic;
 import lombok.RequiredArgsConstructor;
 import maddori.keygo.common.exception.CustomException;
 import maddori.keygo.common.response.BasicResponse;
+import maddori.keygo.common.response.NoDetailSuccessResponse;
 import maddori.keygo.common.response.SuccessResponse;
 import maddori.keygo.service.TeamService;
 import maddori.keygo.dto.team.TeamResponseDto;


### PR DESCRIPTION
## 📝 Summary
<!-- 해당 PR의 주요 내용을 적어주세요 -->
아래 형식을 갖춘 NoDetailSuccessResponse 구현
```json
{
    "success": true,
    "message": "유저 정보 삭제 성공"
}
```

## 👩‍💻 Contents
<!-- 작업 내용을 적어주세요 -->
- NoDetailSuccessResponse 구현
  아래와 같이 사용
  `return NoDetailSuccessResponse.toResponseEntity(GET_TEAM_INFO_SUCCESS);`
- SuccessResponse 객체의 detail 필드 null값 비허용하도록 변경

## 📝 Review Note
<!-- PR과정에서 든 생각이나 개선할 내용이 있다면 적어주세요. -->


## 📣 Related Issue
<!-- 관련 이슈를 적어주세요. -->
- close #10 


## 📬 Reference
<!-- 참고한 코드의 출처를 작성해주세요 -->
