### PR TITLE
[FEAT] 유저가 속한 팀 목록 가져오기(getUserTeamList) api 구현

### DIFF
--- a/src/main/java/maddori/keygo/controller/TeamController.java
+++ b/src/main/java/maddori/keygo/controller/TeamController.java
@@ -2,9 +2,7 @@ package maddori.keygo.controller;
 
 import jakarta.persistence.Basic;
 import lombok.RequiredArgsConstructor;
-import maddori.keygo.common.exception.CustomException;
 import maddori.keygo.common.response.BasicResponse;
-import maddori.keygo.common.response.NoDetailSuccessResponse;
 import maddori.keygo.common.response.SuccessResponse;
 import maddori.keygo.dto.team.TeamNameResponseDto;
 import maddori.keygo.service.TeamService;

--- a/src/main/java/maddori/keygo/controller/UserController.java
+++ b/src/main/java/maddori/keygo/controller/UserController.java
@@ -1,0 +1,34 @@
+package maddori.keygo.controller;
+
+import lombok.RequiredArgsConstructor;
+import maddori.keygo.common.response.BasicResponse;
+import maddori.keygo.common.response.FailResponse;
+import maddori.keygo.common.response.SuccessResponse;
+import maddori.keygo.dto.user.UserTeamListResponseDto;
+import maddori.keygo.service.UserService;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.List;
+
+import static maddori.keygo.common.response.ResponseCode.GET_USER_TEAM_LIST_SUCCESS;
+import static maddori.keygo.common.response.ResponseCode.INTERNAL_SERVER_ERROR;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("api/v2/users")
+public class UserController {
+
+    private final UserService userService;
+
+    @GetMapping("/teams")
+    public ResponseEntity<? extends BasicResponse> getUserTeamList(@RequestHeader("user_id") Long userId) {
+        try {
+            List<UserTeamListResponseDto> userTeamListResponseDtoList = userService.getUserTeamList(userId);
+            return SuccessResponse.toResponseEntity(GET_USER_TEAM_LIST_SUCCESS, userTeamListResponseDtoList);
+        } catch (RuntimeException e) {
+            return FailResponse.toResponseEntity(INTERNAL_SERVER_ERROR);
+        }
+    }
+
+}

--- a/src/main/java/maddori/keygo/domain/entity/UserTeam.java
+++ b/src/main/java/maddori/keygo/domain/entity/UserTeam.java
@@ -1,6 +1,7 @@
 package maddori.keygo.domain.entity;
 
 import jakarta.persistence.*;
+import lombok.Getter;
 import lombok.NoArgsConstructor;
 
 import java.util.ArrayList;
@@ -9,6 +10,7 @@ import java.util.List;
 @Entity
 @Table(name = "userteam")
 @NoArgsConstructor
+@Getter
 public class UserTeam {
 
     @Id @GeneratedValue(strategy = GenerationType.IDENTITY)

--- a/src/main/java/maddori/keygo/dto/user/UserTeamListResponseDto.java
+++ b/src/main/java/maddori/keygo/dto/user/UserTeamListResponseDto.java
@@ -1,0 +1,16 @@
+package maddori.keygo.dto.user;
+
+import lombok.Builder;
+import lombok.Data;
+
+@Data
+public class UserTeamListResponseDto {
+    private Long id;
+    private String team_name;
+
+    @Builder
+    public UserTeamListResponseDto(Long id, String teamName) {
+        this.id = id;
+        this.team_name = teamName;
+    }
+}

--- a/src/main/java/maddori/keygo/dto/user/UserTeamListResponseDto.java
+++ b/src/main/java/maddori/keygo/dto/user/UserTeamListResponseDto.java
@@ -1,16 +1,19 @@
 package maddori.keygo.dto.user;
 
+import com.fasterxml.jackson.annotation.JsonProperty;
 import lombok.Builder;
 import lombok.Data;
 
 @Data
 public class UserTeamListResponseDto {
     private Long id;
-    private String team_name;
+
+    @JsonProperty("team_name")
+    private String teamName;
 
     @Builder
     public UserTeamListResponseDto(Long id, String teamName) {
         this.id = id;
-        this.team_name = teamName;
+        this.teamName = teamName;
     }
 }

--- a/src/main/java/maddori/keygo/repository/UserTeamRepository.java
+++ b/src/main/java/maddori/keygo/repository/UserTeamRepository.java
@@ -1,7 +1,11 @@
 package maddori.keygo.repository;
 
+import maddori.keygo.domain.entity.Team;
 import maddori.keygo.domain.entity.UserTeam;
 import org.springframework.data.jpa.repository.JpaRepository;
 
+import java.util.List;
+
 public interface UserTeamRepository extends JpaRepository<UserTeam, Long> {
+    List<UserTeam> findUserTeamsByUserId(Long userId);
 }

--- a/src/main/java/maddori/keygo/service/UserService.java
+++ b/src/main/java/maddori/keygo/service/UserService.java
@@ -1,0 +1,31 @@
+package maddori.keygo.service;
+
+import lombok.RequiredArgsConstructor;
+import maddori.keygo.domain.entity.UserTeam;
+import maddori.keygo.dto.user.UserTeamListResponseDto;
+import maddori.keygo.repository.UserTeamRepository;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+import java.util.stream.Collectors;
+
+@Service
+@RequiredArgsConstructor
+public class UserService {
+
+    private final UserTeamRepository userTeamRepository;
+
+    @Transactional(readOnly = true)
+    public List<UserTeamListResponseDto> getUserTeamList(Long userId) {
+        List<UserTeam> userTeamList= userTeamRepository.findUserTeamsByUserId(userId);
+        List<UserTeamListResponseDto> result = userTeamList.stream()
+                        .map(r -> UserTeamListResponseDto.builder()
+                                        .id(r.getTeam().getId())
+                                        .teamName(r.getTeam().getTeamName())
+                                        .build())
+                        .collect(Collectors.toList());
+
+        return result;
+    }
+}

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -17,7 +17,7 @@ spring:
         web-allow-others: true
   jpa:
     hibernate:
-      ddl-auto: create
+      ddl-auto: update
     properties:
       hibernate:
         show_sql: true


### PR DESCRIPTION
## 📝 Summary
<!-- 해당 PR의 주요 내용을 적어주세요 -->
유저가 속한 팀 목록 가져오기(getUserTeamList) api 구현

## 👩‍💻 Contents
<!-- 작업 내용을 적어주세요 -->
- UserTeamListResponseDto 활용하여 아래 형식 결과값 반환
  ```json
    "detail": [
      {
          "id": 1,
          "team_name": "맛쟁이사과처럼"
      },
      {
          "id": 3,
          "team_name": "마지"
      }
  ]
  ```
- 결과값이 없을 때는 빈 배열 반환

## 📝 Review Note
<!-- PR과정에서 든 생각이나 개선할 내용이 있다면 적어주세요. -->
추후 유저 검증 로직 구현 후 유저 검증을 추가해야 할 것 같습니다.

## 📣 Related Issue
<!-- 관련 이슈를 적어주세요. -->
- close #7 


## 📬 Reference
<!-- 참고한 코드의 출처를 작성해주세요 -->
