### PR TITLE
[FEAT] 특정 타입 피드백 목록 조회 API 구현

### DIFF
--- a/src/main/java/maddori/keygo/controller/FeedbackController.java
+++ b/src/main/java/maddori/keygo/controller/FeedbackController.java
@@ -1,15 +1,21 @@
 package maddori.keygo.controller;
 
+import lombok.Builder;
+import lombok.Data;
 import lombok.RequiredArgsConstructor;
 import maddori.keygo.common.response.BasicResponse;
 import maddori.keygo.common.response.FailResponse;
 import maddori.keygo.common.response.ResponseCode;
 import maddori.keygo.common.response.SuccessResponse;
+import maddori.keygo.dto.feedback.FeedbackResponseDto;
 import maddori.keygo.dto.feedback.FeedbackUpdateRequestDto;
 import maddori.keygo.dto.feedback.FeedbackUpdateResponseDto;
+import maddori.keygo.dto.reflection.ReflectionResponseDto;
 import maddori.keygo.service.FeedbackService;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
+
+import java.util.List;
 
 @RestController
 @RequestMapping("/api/v2/teams")
@@ -47,5 +53,29 @@ public class FeedbackController {
         catch (RuntimeException e) {
             return FailResponse.toResponseEntity(ResponseCode.INTERNAL_SERVER_ERROR);
         }
+    }
+
+    @GetMapping("/{teamId}/reflections/{reflection_id}/feedbacks")
+    public ResponseEntity<? extends BasicResponse> getCertainTypeFeedbackAll(
+            @RequestParam("type") String type,
+            @PathVariable("teamId") Long teamId,
+            @PathVariable("reflection_id") Long reflectionId
+    ) {
+        try {
+
+            List<FeedbackResponseDto> responseDtoList = feedbackService.getFeedbackList(type, teamId, reflectionId);
+            FeedbackListResponseDto responseData = FeedbackListResponseDto.builder()
+                    .feedback(responseDtoList)
+                    .build();
+            return SuccessResponse.toResponseEntity(ResponseCode.GET_FEEDBACK_SUCCESS, responseDtoList);
+        } catch (RuntimeException e) {
+            return FailResponse.toResponseEntity(ResponseCode.INTERNAL_SERVER_ERROR);
+        }
+    }
+
+    @Data
+    @Builder
+    public static class FeedbackListResponseDto {
+        private List<FeedbackResponseDto> feedback;
     }
 }

--- a/src/main/java/maddori/keygo/controller/FeedbackController.java
+++ b/src/main/java/maddori/keygo/controller/FeedbackController.java
@@ -59,18 +59,14 @@ public class FeedbackController {
     public ResponseEntity<? extends BasicResponse> getCertainTypeFeedbackAll(
             @RequestParam("type") String type,
             @PathVariable("teamId") Long teamId,
-            @PathVariable("reflection_id") Long reflectionId
+            @PathVariable("reflection_id") Long reflectionId,
+            Long userId
     ) {
-        try {
-
-            List<FeedbackResponseDto> responseDtoList = feedbackService.getFeedbackList(type, teamId, reflectionId);
-            FeedbackListResponseDto responseData = FeedbackListResponseDto.builder()
-                    .feedback(responseDtoList)
-                    .build();
-            return SuccessResponse.toResponseEntity(ResponseCode.GET_FEEDBACK_SUCCESS, responseDtoList);
-        } catch (RuntimeException e) {
-            return FailResponse.toResponseEntity(ResponseCode.INTERNAL_SERVER_ERROR);
-        }
+        List<FeedbackResponseDto> responseDtoList = feedbackService.getFeedbackList(type, teamId, reflectionId, userId);
+        FeedbackListResponseDto responseData = FeedbackListResponseDto.builder()
+                .feedback(responseDtoList)
+                .build();
+        return SuccessResponse.toResponseEntity(ResponseCode.GET_FEEDBACK_SUCCESS, responseData);
     }
 
     @Data

--- a/src/main/java/maddori/keygo/dto/feedback/FeedbackResponseDto.java
+++ b/src/main/java/maddori/keygo/dto/feedback/FeedbackResponseDto.java
@@ -1,0 +1,27 @@
+package maddori.keygo.dto.feedback;
+
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import lombok.Builder;
+import lombok.Data;
+import maddori.keygo.dto.user.UserDto;
+
+@Data
+public class FeedbackResponseDto {
+
+    private Long id;
+    private String type;
+    private String keyword;
+    private String content;
+    @JsonProperty("from_user")
+    private UserDto fromUser;
+
+    @Builder
+    public FeedbackResponseDto(Long id, String type, String keyword, String content, UserDto fromUser) {
+        this.id = id;
+        this.type = type;
+        this.keyword = keyword;
+        this.content = content;
+        this.fromUser = fromUser;
+    }
+}

--- a/src/main/java/maddori/keygo/dto/user/UserDto.java
+++ b/src/main/java/maddori/keygo/dto/user/UserDto.java
@@ -6,11 +6,11 @@ import lombok.Data;
 @Data
 public class UserDto {
     private Long id;
-    private String nickName;
+    private String nickname;
 
     @Builder
-    public UserDto(Long id, String nickName) {
+    public UserDto(Long id, String nickname) {
         this.id = id;
-        this.nickName = nickName;
+        this.nickname = nickname;
     }
 }

--- a/src/main/java/maddori/keygo/repository/FeedbackRepository.java
+++ b/src/main/java/maddori/keygo/repository/FeedbackRepository.java
@@ -1,9 +1,14 @@
 package maddori.keygo.repository;
 
+import maddori.keygo.domain.CssType;
 import maddori.keygo.domain.entity.Feedback;
 import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.List;
 
 public interface FeedbackRepository extends JpaRepository<Feedback, Long> {
 
     public void deleteById(Long id);
+
+    public List<Feedback> findAllByTypeAndReflectionId(CssType type, Long reflectionId);
 }

--- a/src/main/java/maddori/keygo/repository/UserTeamRepository.java
+++ b/src/main/java/maddori/keygo/repository/UserTeamRepository.java
@@ -5,7 +5,10 @@ import maddori.keygo.domain.entity.UserTeam;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 import java.util.List;
+import java.util.Optional;
 
 public interface UserTeamRepository extends JpaRepository<UserTeam, Long> {
     List<UserTeam> findUserTeamsByUserId(Long userId);
+
+    Optional<UserTeam> findUserTeamsByUserIdAndTeamId(Long userId, Long teamId);
 }

--- a/src/main/java/maddori/keygo/service/FeedbackService.java
+++ b/src/main/java/maddori/keygo/service/FeedbackService.java
@@ -69,7 +69,7 @@ public class FeedbackService {
                         .content(feedback.getContent())
                         .fromUser(UserDto.builder()
                                 .id(feedback.getFromUser().getId())
-                                .nickname(userTeam.getNickname())
+                                .nickname(userTeamRepository.findUserTeamsByUserIdAndTeamId(feedback.getFromUser().getId(), teamId).get().getNickname())
                                 .build())
                         .build())
                 .collect(Collectors.toList());

--- a/src/main/java/maddori/keygo/service/FeedbackService.java
+++ b/src/main/java/maddori/keygo/service/FeedbackService.java
@@ -5,11 +5,13 @@ import maddori.keygo.common.exception.CustomException;
 import maddori.keygo.common.response.ResponseCode;
 import maddori.keygo.domain.CssType;
 import maddori.keygo.domain.entity.Feedback;
+import maddori.keygo.domain.entity.UserTeam;
 import maddori.keygo.dto.feedback.FeedbackResponseDto;
 import maddori.keygo.dto.feedback.FeedbackUpdateRequestDto;
 import maddori.keygo.dto.feedback.FeedbackUpdateResponseDto;
 import maddori.keygo.dto.user.UserDto;
 import maddori.keygo.repository.FeedbackRepository;
+import maddori.keygo.repository.UserTeamRepository;
 import org.springframework.stereotype.Service;
 
 import java.util.List;
@@ -19,6 +21,8 @@ import java.util.stream.Collectors;
 @RequiredArgsConstructor
 public class FeedbackService {
     private final FeedbackRepository feedbackRepository;
+
+    private final UserTeamRepository userTeamRepository;
 
     public void delete(Long TeamId, Long reflectionId, Long feedbackId) {
         feedbackRepository.deleteById(feedbackId);
@@ -37,7 +41,7 @@ public class FeedbackService {
 
         UserDto userDto = UserDto.builder()
                 .id(feedback.getToUser().getId())
-                .nickName(feedback.getToUser().getUsername())
+                .nickname(feedback.getToUser().getUsername())
                 .build();
 
         FeedbackUpdateResponseDto feedbackUpdateResponseDto = FeedbackUpdateResponseDto.builder()
@@ -50,17 +54,22 @@ public class FeedbackService {
         return feedbackUpdateResponseDto;
     }
 
-    public List<FeedbackResponseDto> getFeedbackList(String type, Long teamId, Long reflectionId) {
+    public List<FeedbackResponseDto> getFeedbackList(String type, Long teamId, Long reflectionId, Long userId) {
+
+        UserTeam userTeam = userTeamRepository.findUserTeamsByUserIdAndTeamId(userId, teamId)
+                .orElseThrow(() -> new CustomException(ResponseCode.TEAM_NOT_EXIST));
+
         return feedbackRepository.findAllByTypeAndReflectionId(toType(type), reflectionId)
                 .stream()
                 .map(feedback -> FeedbackResponseDto.builder()
                         .id(feedback.getId())
                         .type(feedback.getType().getValue())
                         .keyword(feedback.getKeyword())
+                        .keyword(feedback.getKeyword())
                         .content(feedback.getContent())
                         .fromUser(UserDto.builder()
-                                .id(feedback.getToUser().getId())
-                                .nickName(feedback.getToUser().getUsername())
+                                .id(feedback.getFromUser().getId())
+                                .nickname(userTeam.getNickname())
                                 .build())
                         .build())
                 .collect(Collectors.toList());

--- a/src/main/java/maddori/keygo/service/FeedbackService.java
+++ b/src/main/java/maddori/keygo/service/FeedbackService.java
@@ -5,11 +5,15 @@ import maddori.keygo.common.exception.CustomException;
 import maddori.keygo.common.response.ResponseCode;
 import maddori.keygo.domain.CssType;
 import maddori.keygo.domain.entity.Feedback;
+import maddori.keygo.dto.feedback.FeedbackResponseDto;
 import maddori.keygo.dto.feedback.FeedbackUpdateRequestDto;
 import maddori.keygo.dto.feedback.FeedbackUpdateResponseDto;
 import maddori.keygo.dto.user.UserDto;
 import maddori.keygo.repository.FeedbackRepository;
 import org.springframework.stereotype.Service;
+
+import java.util.List;
+import java.util.stream.Collectors;
 
 @Service
 @RequiredArgsConstructor
@@ -46,12 +50,28 @@ public class FeedbackService {
         return feedbackUpdateResponseDto;
     }
 
+    public List<FeedbackResponseDto> getFeedbackList(String type, Long teamId, Long reflectionId) {
+        return feedbackRepository.findAllByTypeAndReflectionId(toType(type), reflectionId)
+                .stream()
+                .map(feedback -> FeedbackResponseDto.builder()
+                        .id(feedback.getId())
+                        .type(feedback.getType().getValue())
+                        .keyword(feedback.getKeyword())
+                        .content(feedback.getContent())
+                        .fromUser(UserDto.builder()
+                                .id(feedback.getToUser().getId())
+                                .nickName(feedback.getToUser().getUsername())
+                                .build())
+                        .build())
+                .collect(Collectors.toList());
+    }
+
     private CssType toType(String type) {
         CssType value = switch (type)
         {
             case "Continue" -> CssType.Continue;
             case "Stop" -> CssType.Stop;
-            default -> CssType.Continue;
+            default -> throw new CustomException(ResponseCode.BAD_REQUEST);
         };
         return value;
     }

--- a/src/test/java/maddori/keygo/service/FeedbackServiceTest.java
+++ b/src/test/java/maddori/keygo/service/FeedbackServiceTest.java
@@ -106,7 +106,7 @@ public class FeedbackServiceTest {
         }
     //when
         List<FeedbackResponseDto> dtoList = feedbackService.getFeedbackList(CssType.Continue.getValue(),
-                team.getId(), reflection.getId());
+                team.getId(), reflection.getId(), 1L);
         for (FeedbackResponseDto dto : dtoList) {
             assertThat(dto.getType()).isEqualTo(CssType.Continue.getValue());
             assertThat(dto.getContent()).isEqualTo("content");

--- a/src/test/java/maddori/keygo/service/FeedbackServiceTest.java
+++ b/src/test/java/maddori/keygo/service/FeedbackServiceTest.java
@@ -1,11 +1,13 @@
 package maddori.keygo.service;
 
+import maddori.keygo.controller.FeedbackController;
 import maddori.keygo.domain.CssType;
 import maddori.keygo.domain.ReflectionState;
 import maddori.keygo.domain.entity.Feedback;
 import maddori.keygo.domain.entity.Reflection;
 import maddori.keygo.domain.entity.Team;
 import maddori.keygo.domain.entity.User;
+import maddori.keygo.dto.feedback.FeedbackResponseDto;
 import maddori.keygo.dto.feedback.FeedbackUpdateRequestDto;
 import maddori.keygo.dto.feedback.FeedbackUpdateResponseDto;
 import maddori.keygo.repository.FeedbackRepository;
@@ -19,6 +21,8 @@ import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.transaction.annotation.Transactional;
 
 import java.time.LocalDateTime;
+import java.util.ArrayList;
+import java.util.List;
 
 import static org.assertj.core.api.Assertions.*;
 
@@ -78,7 +82,38 @@ public class FeedbackServiceTest {
         assertThat(dto.getContent()).isEqualTo(updatedFeedback.getContent());
 
     }
-
+    
+    @Test
+    public void getFeedbackListSuccess() throws Exception {
+        //given
+        Team team = createTeam();
+        Reflection reflection = createReflection(team);
+        List<Feedback> feedbackList = new ArrayList<>();
+        for (Long i = 1L; i <= 10L; i++) {
+            Feedback feedback = Feedback.builder()
+                    .id(i)
+                    .startContent("start content")
+                    .content("content")
+                    .toUser(createToUser())
+                    .fromUser(createFromUser())
+                    .type(CssType.Continue)
+                    .team(team)
+                    .reflection(reflection)
+                    .keyword("keyword")
+                    .build();
+            feedbackRepository.save(feedback);
+            feedbackList.add(feedback);
+        }
+    //when
+        List<FeedbackResponseDto> dtoList = feedbackService.getFeedbackList(CssType.Continue.getValue(),
+                team.getId(), reflection.getId());
+        for (FeedbackResponseDto dto : dtoList) {
+            assertThat(dto.getType()).isEqualTo(CssType.Continue.getValue());
+            assertThat(dto.getContent()).isEqualTo("content");
+            assertThat(dto.getFromUser().getId()).isEqualTo(1L);
+            }
+        assertThat(dtoList.size()).isEqualTo(feedbackList.size());
+    }
 
     private User createToUser() {
         User toUser =  User.builder()


### PR DESCRIPTION
## 📝 Summary
<!-- 해당 PR의 주요 내용을 적어주세요 -->
[FEAT] 현재 회고에서 특정 타입 피드백 목록 조회 API 구현

## 👩‍💻 Contents
<!-- 작업 내용을 적어주세요 -->
- Feedback Dto 생성
- Controller, Service, Respository에 피드백 목록 조회를 위한 로직 구현


## 📝 Review Note
<!-- PR과정에서 든 생각이나 개선할 내용이 있다면 적어주세요. -->
- Test code를 어떻게 짜는게 맞는지,,, 어렵네요.

## 📣 Related Issue
<!-- 관련 이슈를 적어주세요. -->
- close #19 


## 📬 Reference
<!-- 참고한 코드의 출처를 작성해주세요 -->
