### PR TITLE
[FEAT] 회고 진행 중 화면에서 멤버를 선택한 후, 해당 멤버가 진행 중인 회고에서 받은 피드백 가져오는 API 구현

### DIFF
--- a/src/main/java/maddori/keygo/controller/FeedbackController.java
+++ b/src/main/java/maddori/keygo/controller/FeedbackController.java
@@ -10,6 +10,7 @@ import maddori.keygo.common.response.SuccessResponse;
 import maddori.keygo.dto.feedback.FeedbackResponseDto;
 import maddori.keygo.dto.feedback.FeedbackUpdateRequestDto;
 import maddori.keygo.dto.feedback.FeedbackUpdateResponseDto;
+import maddori.keygo.dto.feedback.FeedbackUserAndTeamResponseDto;
 import maddori.keygo.dto.reflection.ReflectionResponseDto;
 import maddori.keygo.service.FeedbackService;
 import org.springframework.http.ResponseEntity;
@@ -71,6 +72,18 @@ public class FeedbackController {
         } catch (RuntimeException e) {
             return FailResponse.toResponseEntity(ResponseCode.INTERNAL_SERVER_ERROR);
         }
+    }
+
+    @GetMapping("/{teamId}/reflections/{reflection_id}/feedbackss")
+    public ResponseEntity<? extends BasicResponse> getTeamAndUserFeedback(
+            Long userId,
+            @RequestParam("members") Long memberId,
+            @PathVariable("teamId") Long teamId,
+            @PathVariable("reflection_id") Long reflectionId
+    ) {
+        FeedbackUserAndTeamResponseDto responseDto =
+                feedbackService.getUserAndTeamFeedbackList(userId, teamId, reflectionId, memberId);
+        return SuccessResponse.toResponseEntity(ResponseCode.GET_FEEDBACK_SUCCESS, null);
     }
 
     @Data

--- a/src/main/java/maddori/keygo/controller/FeedbackController.java
+++ b/src/main/java/maddori/keygo/controller/FeedbackController.java
@@ -74,16 +74,16 @@ public class FeedbackController {
         }
     }
 
-    @GetMapping("/{teamId}/reflections/{reflection_id}/feedbackss")
+    @GetMapping("/{teamId}/reflections/{reflectionId}/feedbacks/from-team")
     public ResponseEntity<? extends BasicResponse> getTeamAndUserFeedback(
             Long userId,
             @RequestParam("members") Long memberId,
             @PathVariable("teamId") Long teamId,
-            @PathVariable("reflection_id") Long reflectionId
+            @PathVariable("reflectionId") Long reflectionId
     ) {
         FeedbackUserAndTeamResponseDto responseDto =
                 feedbackService.getUserAndTeamFeedbackList(userId, teamId, reflectionId, memberId);
-        return SuccessResponse.toResponseEntity(ResponseCode.GET_FEEDBACK_SUCCESS, null);
+        return SuccessResponse.toResponseEntity(ResponseCode.GET_FEEDBACK_SUCCESS, responseDto);
     }
 
     @Data

--- a/src/main/java/maddori/keygo/dto/feedback/FeedbackUserAndTeamResponseDto.java
+++ b/src/main/java/maddori/keygo/dto/feedback/FeedbackUserAndTeamResponseDto.java
@@ -1,0 +1,28 @@
+package maddori.keygo.dto.feedback;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import lombok.Builder;
+import lombok.Data;
+import maddori.keygo.domain.entity.Feedback;
+
+import java.util.ArrayList;
+import java.util.List;
+
+@Data
+public class FeedbackUserAndTeamResponseDto {
+
+    private String category;
+
+    @JsonProperty("user_feedback")
+    List<FeedbackResponseDto> userFeedbackList = new ArrayList<>();
+
+    @JsonProperty("team_feedback")
+    List<FeedbackResponseDto> teamFeedbackList = new ArrayList<>();
+
+    @Builder
+    public FeedbackUserAndTeamResponseDto(String category, List<FeedbackResponseDto> userFeedbackList, List<FeedbackResponseDto> teamFeedbackList) {
+        this.category = category;
+        this.userFeedbackList = userFeedbackList;
+        this.teamFeedbackList = teamFeedbackList;
+    }
+}

--- a/src/main/java/maddori/keygo/repository/FeedbackRepository.java
+++ b/src/main/java/maddori/keygo/repository/FeedbackRepository.java
@@ -16,7 +16,7 @@ public interface FeedbackRepository extends JpaRepository<Feedback, Long> {
 
     public List<Feedback> findAllByToUserAndFromUserIdAndReflectionId(Long memberId, Long userId, Long reflectionId);
 
-    @Query("select f from Feedback f where f.fromUser.id = :memberId and f.fromUser .id <> :userId and f.reflection.id = :reflectionId")
+    @Query("select f from Feedback f where f.toUser.id = :memberId and f.fromUser .id <> :userId and f.reflection.id = :reflectionId")
     public List<Feedback> findAllByToUserExceptFromUserIdAndReflectionId(
             @Param("memberId") Long memberId,
             @Param("userId") Long userId,

--- a/src/main/java/maddori/keygo/repository/FeedbackRepository.java
+++ b/src/main/java/maddori/keygo/repository/FeedbackRepository.java
@@ -14,10 +14,11 @@ public interface FeedbackRepository extends JpaRepository<Feedback, Long> {
 
     public List<Feedback> findAllByTypeAndReflectionId(CssType type, Long reflectionId);
 
-    public List<Feedback> findAllByFromUserIdAndReflectionId(Long userId, Long reflectionId);
+    public List<Feedback> findAllByToUserAndFromUserIdAndReflectionId(Long memberId, Long userId, Long reflectionId);
 
-    @Query("select f from Feedback f where f.fromUser .id <> :userId and f.reflection.id = :reflectionId")
-    public List<Feedback> findAllExceptFromUserIdAndReflectionId(
+    @Query("select f from Feedback f where f.fromUser.id = :memberId and f.fromUser .id <> :userId and f.reflection.id = :reflectionId")
+    public List<Feedback> findAllByToUserExceptFromUserIdAndReflectionId(
+            @Param("memberId") Long memberId,
             @Param("userId") Long userId,
             @Param("reflectionId") Long reflectionId);
 }

--- a/src/main/java/maddori/keygo/repository/FeedbackRepository.java
+++ b/src/main/java/maddori/keygo/repository/FeedbackRepository.java
@@ -3,6 +3,8 @@ package maddori.keygo.repository;
 import maddori.keygo.domain.CssType;
 import maddori.keygo.domain.entity.Feedback;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
 import java.util.List;
 
@@ -11,4 +13,11 @@ public interface FeedbackRepository extends JpaRepository<Feedback, Long> {
     public void deleteById(Long id);
 
     public List<Feedback> findAllByTypeAndReflectionId(CssType type, Long reflectionId);
+
+    public List<Feedback> findAllByFromUserIdAndReflectionId(Long userId, Long reflectionId);
+
+    @Query("select f from Feedback f where f.fromUser .id <> :userId and f.reflection.id = :reflectionId")
+    public List<Feedback> findAllExceptFromUserIdAndReflectionId(
+            @Param("userId") Long userId,
+            @Param("reflectionId") Long reflectionId);
 }

--- a/src/main/java/maddori/keygo/repository/UserTeamRepository.java
+++ b/src/main/java/maddori/keygo/repository/UserTeamRepository.java
@@ -5,7 +5,10 @@ import maddori.keygo.domain.entity.UserTeam;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 import java.util.List;
+import java.util.Optional;
 
 public interface UserTeamRepository extends JpaRepository<UserTeam, Long> {
     List<UserTeam> findUserTeamsByUserId(Long userId);
+
+    Optional<UserTeam> findUserTeamsByUserIdAndTeamId(Long userId, Long teamId);
 }

--- a/src/main/java/maddori/keygo/service/FeedbackService.java
+++ b/src/main/java/maddori/keygo/service/FeedbackService.java
@@ -64,8 +64,8 @@ public class FeedbackService {
                         .keyword(feedback.getKeyword())
                         .content(feedback.getContent())
                         .fromUser(UserDto.builder()
-                                .id(feedback.getToUser().getId())
-                                .nickName(feedback.getToUser().getUsername())
+                                .id(feedback.getFromUser().getId())
+                                .nickName(userTeamRepository.findUserTeamsByUserIdAndTeamId(feedback.getFromUser().getId(), teamId).get().getNickname())
                                 .build())
                         .build())
                 .collect(Collectors.toList());
@@ -86,8 +86,8 @@ public class FeedbackService {
                         .keyword(feedback.getKeyword())
                         .content(feedback.getContent())
                         .fromUser(UserDto.builder()
-                                .id(feedback.getToUser().getId())
-                                .nickName(feedback.getToUser().getUsername())
+                                .id(feedback.getFromUser().getId())
+                                .nickName(userTeamRepository.findUserTeamsByUserIdAndTeamId(feedback.getFromUser().getId(), teamId).get().getNickname())
                                 .build())
                         .build())
                 .collect(Collectors.toList());
@@ -102,8 +102,8 @@ public class FeedbackService {
                                 .keyword(feedback.getKeyword())
                                 .content(feedback.getContent())
                                 .fromUser(UserDto.builder()
-                                        .id(feedback.getToUser().getId())
-                                        .nickName(userTeam.getNickname())
+                                        .id(feedback.getFromUser().getId())
+                                        .nickName(userTeamRepository.findUserTeamsByUserIdAndTeamId(feedback.getFromUser().getId(), teamId).get().getNickname())
                                         .build())
                                 .build())
                         .collect(Collectors.toList());

--- a/src/main/java/maddori/keygo/service/FeedbackService.java
+++ b/src/main/java/maddori/keygo/service/FeedbackService.java
@@ -5,12 +5,14 @@ import maddori.keygo.common.exception.CustomException;
 import maddori.keygo.common.response.ResponseCode;
 import maddori.keygo.domain.CssType;
 import maddori.keygo.domain.entity.Feedback;
+import maddori.keygo.domain.entity.UserTeam;
 import maddori.keygo.dto.feedback.FeedbackResponseDto;
 import maddori.keygo.dto.feedback.FeedbackUpdateRequestDto;
 import maddori.keygo.dto.feedback.FeedbackUpdateResponseDto;
 import maddori.keygo.dto.feedback.FeedbackUserAndTeamResponseDto;
 import maddori.keygo.dto.user.UserDto;
 import maddori.keygo.repository.FeedbackRepository;
+import maddori.keygo.repository.UserTeamRepository;
 import org.springframework.stereotype.Service;
 
 import java.util.List;
@@ -20,6 +22,8 @@ import java.util.stream.Collectors;
 @RequiredArgsConstructor
 public class FeedbackService {
     private final FeedbackRepository feedbackRepository;
+
+    private final UserTeamRepository userTeamRepository;
 
     public void delete(Long TeamId, Long reflectionId, Long feedbackId) {
         feedbackRepository.deleteById(feedbackId);
@@ -68,15 +72,14 @@ public class FeedbackService {
     }
 
     // TODO: userID 맞춰서 수정.
-    public FeedbackUserAndTeamResponseDto getUserAndTeamFeedbackList(
-            Long userId,
-            Long teamId,
-            Long reflectionId,
-            Long memberId
-    ) {
+    public FeedbackUserAndTeamResponseDto getUserAndTeamFeedbackList(Long userId, Long teamId, Long reflectionId, Long memberId) {
         // 팀의 회고 중에서, 본인이 쓴 feedback
+
+        UserTeam userTeam = userTeamRepository.findUserTeamsByUserIdAndTeamId(userId, teamId)
+                .orElseThrow(() -> new CustomException(ResponseCode.TEAM_NOT_EXIST));
+
         List<FeedbackResponseDto> userFeedbackList =
-        feedbackRepository.findAllByFromUserIdAndReflectionId(userId, reflectionId)
+        feedbackRepository.findAllByToUserAndFromUserIdAndReflectionId(memberId, userId, reflectionId)
                 .stream().map(feedback -> FeedbackResponseDto.builder()
                         .id(feedback.getId())
                         .type(feedback.getType().getValue())
@@ -92,7 +95,7 @@ public class FeedbackService {
 
         // 팀의 회고 중에서, 본인을 제외한 팀의 피드백
         List<FeedbackResponseDto> teamFeedbackList =
-                feedbackRepository.findAllExceptFromUserIdAndReflectionId(userId, reflectionId)
+                feedbackRepository.findAllByToUserExceptFromUserIdAndReflectionId(memberId, userId, reflectionId)
                         .stream().map(feedback -> FeedbackResponseDto.builder()
                                 .id(feedback.getId())
                                 .type(feedback.getType().getValue())
@@ -100,7 +103,7 @@ public class FeedbackService {
                                 .content(feedback.getContent())
                                 .fromUser(UserDto.builder()
                                         .id(feedback.getToUser().getId())
-                                        .nickName(feedback.getToUser().getUsername())
+                                        .nickName(userTeam.getNickname())
                                         .build())
                                 .build())
                         .collect(Collectors.toList());

--- a/src/test/java/maddori/keygo/service/FeedbackServiceTest.java
+++ b/src/test/java/maddori/keygo/service/FeedbackServiceTest.java
@@ -1,6 +1,5 @@
 package maddori.keygo.service;
 
-import maddori.keygo.controller.FeedbackController;
 import maddori.keygo.domain.CssType;
 import maddori.keygo.domain.ReflectionState;
 import maddori.keygo.domain.entity.Feedback;
@@ -14,7 +13,6 @@ import maddori.keygo.repository.FeedbackRepository;
 import maddori.keygo.repository.ReflectionRepository;
 import maddori.keygo.repository.TeamRepository;
 import maddori.keygo.repository.UserRepository;
-import org.assertj.core.api.Assertions;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;


### PR DESCRIPTION
## 📝 Summary
<!-- 해당 PR의 주요 내용을 적어주세요 -->

현재 회고에서 유저가 받은 css 피드백 정보 모두 가져오기 or 현재 팀의 현재 회고에서 특정 멤버가 쓴 피드백 중 유저가 쓴 피드백과 다른 멤버들이 쓴 피드백 정보 분류해서 가져오기

## 👩‍💻 Contents
<!-- 작업 내용을 적어주세요 -->
- Controller, Service, Repository, dto 작업

## 📝 Review Note
<!-- PR과정에서 든 생각이나 개선할 내용이 있다면 적어주세요. -->
- Test code 짜기 어렵네요.. 추가하겠습니다..

## 📣 Related Issue
<!-- 관련 이슈를 적어주세요. -->
- close #21 


## 📬 Reference
<!-- 참고한 코드의 출처를 작성해주세요 -->
