### PR TITLE
[FEAT] handleUnexpectedException 핸들러 구현

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -37,3 +37,4 @@ out/
 .vscode/
 
 application-config.yml
+.DS_Store

--- a/src/main/java/maddori/keygo/common/exception/GlobalExceptionHandler.java
+++ b/src/main/java/maddori/keygo/common/exception/GlobalExceptionHandler.java
@@ -2,9 +2,12 @@ package maddori.keygo.common.exception;
 
 import maddori.keygo.common.response.BasicResponse;
 import maddori.keygo.common.response.FailResponse;
+import maddori.keygo.common.response.ResponseCode;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.ControllerAdvice;
 import org.springframework.web.bind.annotation.ExceptionHandler;
+
+import static maddori.keygo.common.response.ResponseCode.*;
 
 @ControllerAdvice
 public class GlobalExceptionHandler {
@@ -12,4 +15,12 @@ public class GlobalExceptionHandler {
     protected ResponseEntity<BasicResponse> handleCustomException(CustomException e) {
         return FailResponse.toResponseEntity(e.getResponseCode());
     }
+
+    @ExceptionHandler(Exception.class)
+    protected ResponseEntity<BasicResponse> handleUnexpectedException(Exception e) {
+        return FailResponse.toResponseEntity(INTERNAL_SERVER_ERROR);
+    }
+
 }
+
+

--- a/src/main/java/maddori/keygo/common/exception/GlobalExceptionHandler.java
+++ b/src/main/java/maddori/keygo/common/exception/GlobalExceptionHandler.java
@@ -21,6 +21,8 @@ public class GlobalExceptionHandler {
         return FailResponse.toResponseEntity(INTERNAL_SERVER_ERROR);
     }
 
+
+
 }
 
 

--- a/src/main/java/maddori/keygo/controller/FeedbackController.java
+++ b/src/main/java/maddori/keygo/controller/FeedbackController.java
@@ -25,11 +25,7 @@ public class FeedbackController {
             @PathVariable("reflectionId") Long reflectionId,
             @PathVariable("feedbackId") Long feedbackId
     ) {
-        try {
-            feedbackService.delete(teamId, reflectionId, feedbackId);
-            return SuccessResponse.toResponseEntity(ResponseCode.DELETE_FEEDBACK_SUCCESS, null);
-        } catch (RuntimeException e) {
-            return FailResponse.toResponseEntity(ResponseCode.DELETE_FEEDBACK_NOT_EXIST);
-        }
+        feedbackService.delete(teamId, reflectionId, feedbackId);
+        return SuccessResponse.toResponseEntity(ResponseCode.DELETE_FEEDBACK_SUCCESS, null);
     }
 }

--- a/src/main/java/maddori/keygo/controller/ReflectionController.java
+++ b/src/main/java/maddori/keygo/controller/ReflectionController.java
@@ -26,18 +26,12 @@ public class ReflectionController {
     public ResponseEntity<? extends BasicResponse> getPastReflectionList(
             @PathVariable("teamId") Long teamId
     ) {
-        try {
-            List<ReflectionResponseDto> reflectionResponseDtoList = reflectionService.getPastReflectionList(teamId);
-            ReflectionListResponseDto responseData = ReflectionListResponseDto.builder()
-                    .reflection(reflectionResponseDtoList)
-                    .build();
+        List<ReflectionResponseDto> reflectionResponseDtoList = reflectionService.getPastReflectionList(teamId);
+        ReflectionListResponseDto responseData = ReflectionListResponseDto.builder()
+                .reflection(reflectionResponseDtoList)
+                .build();
 
-            return SuccessResponse.toResponseEntity(ResponseCode.GET_REFLECTION_LIST_SUCCESS, responseData);
-        }
-        catch (RuntimeException e) {
-            return FailResponse.toResponseEntity(ResponseCode.GET_REFLECTION_LIST_FAIL);
-        }
-
+        return SuccessResponse.toResponseEntity(ResponseCode.GET_REFLECTION_LIST_SUCCESS, responseData);
     }
 
     @Data

--- a/src/main/java/maddori/keygo/controller/TeamController.java
+++ b/src/main/java/maddori/keygo/controller/TeamController.java
@@ -22,13 +22,8 @@ public class TeamController {
 
     @GetMapping("/{teamId}")
     public ResponseEntity<? extends BasicResponse> getCertainTeamDetail(@PathVariable("teamId") String teamId) {
-        try {
-
-            TeamResponseDto teamResponseDto = teamService.getCertainTeam(teamId);
-            return SuccessResponse.toResponseEntity(GET_TEAM_INFO_SUCCESS, teamResponseDto);
-        } catch (RuntimeException e) {
-            return FailResponse.toResponseEntity(INTERNAL_SERVER_ERROR);
-        }
+        TeamResponseDto teamResponseDto = teamService.getCertainTeam(teamId);
+        return SuccessResponse.toResponseEntity(GET_TEAM_INFO_SUCCESS, teamResponseDto);
     }
 
     @GetMapping("")

--- a/src/main/java/maddori/keygo/controller/UserController.java
+++ b/src/main/java/maddori/keygo/controller/UserController.java
@@ -28,12 +28,8 @@ public class UserController {
 
     @GetMapping("/teams")
     public ResponseEntity<? extends BasicResponse> getUserTeamList(@RequestHeader("user_id") Long userId) {
-        try {
-            List<UserTeamListResponseDto> userTeamListResponseDtoList = userService.getUserTeamList(userId);
-            return SuccessResponse.toResponseEntity(GET_USER_TEAM_LIST_SUCCESS, userTeamListResponseDtoList);
-        } catch (RuntimeException e) {
-            return FailResponse.toResponseEntity(INTERNAL_SERVER_ERROR);
-        }
+        List<UserTeamListResponseDto> userTeamListResponseDtoList = userService.getUserTeamList(userId);
+        return SuccessResponse.toResponseEntity(GET_USER_TEAM_LIST_SUCCESS, userTeamListResponseDtoList);
     }
     @CrossOrigin
     @PostMapping("/join-team/{teamId}")

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -20,7 +20,7 @@ spring:
       matching-strategy: ant_path_matcher
   jpa:
     hibernate:
-      ddl-auto: update
+      ddl-auto: create
     properties:
       hibernate:
         show_sql: true


### PR DESCRIPTION
## 📝 Summary
<!-- 해당 PR의 주요 내용을 적어주세요 -->
핸들링하지 못한 Exception을 캐치해 `INTERNAL_SERVER_ERROR` 를 반환하는 handleUnexpectedException 핸들러 구현

## 👩‍💻 Contents
<!-- 작업 내용을 적어주세요 -->
- handleUnexpectedException 핸들러 구현
  ```json
  {
    "success": false,
    "message": "서버 내부 오류"
  }
  ```

- try-catch문에서 바로 에러 response 보내지 못하도록 수정

## 📝 Review Note
<!-- PR과정에서 든 생각이나 개선할 내용이 있다면 적어주세요. -->


## 📣 Related Issue
<!-- 관련 이슈를 적어주세요. -->
- close #18 


## 📬 Reference
<!-- 참고한 코드의 출처를 작성해주세요 -->
