### PR TITLE
[FEAT] 팀 등록하기 + 유저의 팀 합류와 프로필 생성(createTeam) API 구현

### DIFF
--- a/src/main/java/maddori/keygo/controller/TeamController.java
+++ b/src/main/java/maddori/keygo/controller/TeamController.java
@@ -1,14 +1,23 @@
 package maddori.keygo.controller;
 
+import com.fasterxml.jackson.databind.ObjectMapper;
 import jakarta.persistence.Basic;
 import lombok.RequiredArgsConstructor;
 import maddori.keygo.common.response.BasicResponse;
 import maddori.keygo.common.response.SuccessResponse;
+import maddori.keygo.dto.team.CreateTeamRequestDto;
 import maddori.keygo.dto.team.TeamNameResponseDto;
+import maddori.keygo.dto.user.UserTeamRequestDto;
+import maddori.keygo.dto.user.UserTeamResponseDto;
 import maddori.keygo.service.TeamService;
 import maddori.keygo.dto.team.TeamResponseDto;
 import org.springframework.http.ResponseEntity;
+import org.springframework.lang.Nullable;
 import org.springframework.web.bind.annotation.*;
+import org.springframework.web.multipart.MultipartFile;
+
+import java.io.IOException;
+import java.util.Map;
 
 import static maddori.keygo.common.response.ResponseCode.*;
 
@@ -29,5 +38,16 @@ public class TeamController {
     public ResponseEntity<? extends BasicResponse> getCertainTeamName(@RequestParam("invitation_code") String invitationCode) {
         TeamNameResponseDto teamNameResponseDto = teamService.getCertainTeamName(invitationCode);
         return SuccessResponse.toResponseEntity(GET_TEAM_INFO_SUCCESS, teamNameResponseDto);
+    }
+
+    @PostMapping("")
+    public ResponseEntity<? extends BasicResponse> createTeam(@RequestHeader("user_id") Long userId,
+                                                                @RequestPart("profile_image") @Nullable MultipartFile profileImage,
+                                                                @RequestParam Map<String, String> params) throws IOException {
+
+        ObjectMapper mapper = new ObjectMapper();
+        CreateTeamRequestDto createTeamRequestDto = mapper.convertValue(params, CreateTeamRequestDto.class);
+        UserTeamResponseDto userTeamResponseDto = teamService.createTeamAndJoinTeam(userId, profileImage, createTeamRequestDto);
+        return SuccessResponse.toResponseEntity(CREATE_JOIN_TEAM_SUCCESS, userTeamResponseDto);
     }
 }

--- a/src/main/java/maddori/keygo/controller/TeamController.java
+++ b/src/main/java/maddori/keygo/controller/TeamController.java
@@ -44,7 +44,7 @@ public class TeamController {
     public ResponseEntity<? extends BasicResponse> createTeam(@RequestHeader("user_id") Long userId,
                                                                 @RequestPart("profile_image") @Nullable MultipartFile profileImage,
                                                                 @RequestParam Map<String, String> params) throws IOException {
-
+        // reference: https://tailerbox.tistory.com/30
         ObjectMapper mapper = new ObjectMapper();
         CreateTeamRequestDto createTeamRequestDto = mapper.convertValue(params, CreateTeamRequestDto.class);
         UserTeamResponseDto userTeamResponseDto = teamService.createTeamAndJoinTeam(userId, profileImage, createTeamRequestDto);

--- a/src/main/java/maddori/keygo/domain/entity/Reflection.java
+++ b/src/main/java/maddori/keygo/domain/entity/Reflection.java
@@ -6,6 +6,8 @@ import lombok.Getter;
 import lombok.NoArgsConstructor;
 import maddori.keygo.domain.ReflectionState;
 import org.hibernate.annotations.ColumnDefault;
+import org.hibernate.annotations.DynamicInsert;
+import org.hibernate.annotations.DynamicUpdate;
 import org.springframework.data.annotation.CreatedDate;
 import org.springframework.data.annotation.LastModifiedDate;
 
@@ -14,6 +16,8 @@ import java.time.LocalDateTime;
 @Entity
 @NoArgsConstructor
 @Getter
+@DynamicInsert
+@DynamicUpdate
 public class Reflection {
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)

--- a/src/main/java/maddori/keygo/dto/team/CreateTeamRequestDto.java
+++ b/src/main/java/maddori/keygo/dto/team/CreateTeamRequestDto.java
@@ -1,0 +1,18 @@
+package maddori.keygo.dto.team;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+import maddori.keygo.dto.user.UserTeamRequestDto;
+
+@Data
+@NoArgsConstructor
+public class CreateTeamRequestDto extends UserTeamRequestDto{
+    @JsonProperty("team_name")
+    private String teamName;
+
+    public CreateTeamRequestDto(String teamName, String nickname, String role) {
+        super(nickname, role);
+        this.teamName = teamName;
+    }
+}

--- a/src/main/java/maddori/keygo/dto/user/UserTeamRequestDto.java
+++ b/src/main/java/maddori/keygo/dto/user/UserTeamRequestDto.java
@@ -1,8 +1,10 @@
 package maddori.keygo.dto.user;
 
-import lombok.Data;
+import lombok.*;
 
 @Data
+@NoArgsConstructor
+@AllArgsConstructor
 public class UserTeamRequestDto {
     private String nickname;
     private String role;

--- a/src/main/java/maddori/keygo/service/TeamService.java
+++ b/src/main/java/maddori/keygo/service/TeamService.java
@@ -4,12 +4,15 @@ import jakarta.persistence.EntityNotFoundException;
 import lombok.RequiredArgsConstructor;
 import maddori.keygo.common.exception.CustomException;
 import maddori.keygo.common.response.ResponseCode;
+import maddori.keygo.dto.team.CreateTeamRequestDto;
 import maddori.keygo.dto.team.TeamNameResponseDto;
 import maddori.keygo.dto.team.TeamResponseDto;
 import maddori.keygo.domain.entity.Team;
+import maddori.keygo.dto.user.UserTeamResponseDto;
 import maddori.keygo.repository.TeamRepository;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
+import org.springframework.web.multipart.MultipartFile;
 
 import static maddori.keygo.common.response.ResponseCode.*;
 
@@ -37,5 +40,15 @@ public class TeamService {
                         .teamName(team.getTeamName())
                         .build();
         return response;
+    }
+
+    public UserTeamResponseDto createTeamAndJoinTeam(Long userId, MultipartFile profileImage, CreateTeamRequestDto createTeamRequestDto) {
+
+        return null;
+    }
+
+    public String generateCode() {
+        String generatedCode = "";
+        return generatedCode;
     }
 }

--- a/src/main/java/maddori/keygo/service/TeamService.java
+++ b/src/main/java/maddori/keygo/service/TeamService.java
@@ -1,18 +1,27 @@
 package maddori.keygo.service;
 
-import jakarta.persistence.EntityNotFoundException;
 import lombok.RequiredArgsConstructor;
 import maddori.keygo.common.exception.CustomException;
-import maddori.keygo.common.response.ResponseCode;
+import maddori.keygo.common.util.ImageHandler;
+import maddori.keygo.domain.ReflectionState;
+import maddori.keygo.domain.entity.Reflection;
+import maddori.keygo.domain.entity.User;
+import maddori.keygo.domain.entity.UserTeam;
 import maddori.keygo.dto.team.CreateTeamRequestDto;
 import maddori.keygo.dto.team.TeamNameResponseDto;
 import maddori.keygo.dto.team.TeamResponseDto;
 import maddori.keygo.domain.entity.Team;
 import maddori.keygo.dto.user.UserTeamResponseDto;
+import maddori.keygo.repository.ReflectionRepository;
 import maddori.keygo.repository.TeamRepository;
+import maddori.keygo.repository.UserRepository;
+import maddori.keygo.repository.UserTeamRepository;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 import org.springframework.web.multipart.MultipartFile;
+
+import java.io.IOException;
+import java.util.Random;
 
 import static maddori.keygo.common.response.ResponseCode.*;
 
@@ -20,7 +29,11 @@ import static maddori.keygo.common.response.ResponseCode.*;
 @RequiredArgsConstructor
 public class TeamService {
 
+    private final UserRepository userRepository;
     private final TeamRepository teamRepository;
+    private final ReflectionRepository reflectionRepository;
+    private final UserTeamRepository userTeamRepository;
+
     @Transactional(readOnly = true)
     public TeamResponseDto getCertainTeam(String teamId) {
          Team team = teamRepository.findById(Long.valueOf(teamId)).orElseThrow(() -> new CustomException(TEAM_NOT_EXIST));
@@ -42,13 +55,69 @@ public class TeamService {
         return response;
     }
 
-    public UserTeamResponseDto createTeamAndJoinTeam(Long userId, MultipartFile profileImage, CreateTeamRequestDto createTeamRequestDto) {
+    @Transactional
+    public UserTeamResponseDto createTeamAndJoinTeam(Long userId, MultipartFile profileImage, CreateTeamRequestDto createTeamRequestDto) throws IOException {
+        // 유저 정보
+        User user = userRepository.findById(userId).orElseThrow(() -> new CustomException(USER_NOT_EXIST));
+        // 팀 생성
+        Team team = teamRepository.save(Team.builder()
+                .teamName(createTeamRequestDto.getTeamName())
+                .invitationCode(generateCode())
+                .build());
 
-        return null;
+        // 팀의 첫번째 회고 생성
+        team.updateCurrentReflection(reflectionRepository.save(Reflection.builder()
+                        .team(team)
+                        .state(ReflectionState.SettingRequired)
+                        .build()));
+        teamRepository.save(team);
+
+        // 프로필 이미지 업로드
+        String profileImagePath = (profileImage == null) ? null : ImageHandler.imageUpload(profileImage);
+
+        // userteam 테이블 업데이트
+        UserTeam userTeam = userTeamRepository.save(UserTeam.builder()
+                .user(user)
+                .team(team)
+                .nickname(createTeamRequestDto.getNickname())
+                .role(createTeamRequestDto.getRole())
+                .profileImagePath(profileImagePath)
+                .build());
+
+        UserTeamResponseDto response = UserTeamResponseDto.builder()
+                .id(userTeam.getId())
+                .nickname(userTeam.getNickname())
+                .role(userTeam.getRole())
+                .profileImagePath(profileImagePath)
+                .userId(userTeam.getUser().getId())
+                .team(TeamResponseDto.builder()
+                        .id(team.getId())
+                        .teamName(team.getTeamName())
+                        .invitationCode(team.getInvitationCode())
+                        .build())
+                .build();
+
+        return response;
     }
 
+    // 알파벳 대문자 + 숫자로 이루어진 랜덤 문자열 6자리 생성
+    // reference: https://www.baeldung.com/java-random-string
     public String generateCode() {
-        String generatedCode = "";
+        String generatedCode;
+        int leftLimit = 48; // numeral '0'
+        int rightLimit = 90; // letter 'Z'
+        int targetStringLength = 6;
+        Random random = new Random();
+
+        do {
+            generatedCode = random.ints(leftLimit, rightLimit + 1)
+                    .filter(i -> (i <= 57 || i >= 65))
+                    .limit(targetStringLength)
+                    .collect(StringBuilder::new, StringBuilder::appendCodePoint, StringBuilder::append)
+                    .toString();
+
+        } while(teamRepository.findByInvitationCode(generatedCode).isPresent());
+
         return generatedCode;
     }
 }


### PR DESCRIPTION
## 📝 Summary
<!-- 해당 PR의 주요 내용을 적어주세요 -->
새로운 팀이 생성되고 팀의 invitation_code가 만들어집니다.
이후 팀의 첫번째 회고가 자동 생성되고, 팀 생성 요청을 보낸 유저의 팀 합류와 프로필 생성이 이루어집니다.

## 👩‍💻 Contents
<!-- 작업 내용을 적어주세요 -->
- 로직
  1. 랜덤 초대 코드 생성
  2. 팀 생성
  3. 팀의 회고 생성
  4. 유저의 프로필 이미지 업로드
  5. 유저의 팀 합류

- CreateTeamRequestDto가 UserTeamRequestDto를 상속하도록 구현
  createTeam API에는 유저가 팀을 합류하기 위한 정보(UserTeamRequestDto) + 팀 이름 값이 필요합니다.
  따라서 userJoinTeam API에서 사용하였던 UserTeamRequestDto를 상속받도록 구현하였습니다.
  - 부모 클래스 필드까지 초기화하는 CreateTeamRequestDto 생성자 구현
  - UserTeamRequestDto에 @NoArgsConstructor, @AllArgsConstructor 추가
  - CreateTeamRequestDto에 @NoArgsConstructor 추가

- 응답
  ```json
  {
      "success": true,
      "message": "팀 생성 및 팀 합류 완료",
      "detail": {
          "id": 2,
          "nickname": "nickna",
          "role": "role",
          "team": {
              "id": 2,
              "team_name": "aa",
              "invitation_code": "ZKCY9Z"
          },
          "profile_image_path": "images/filename.png",
          "user_id": 1
      }
  }
  ```

- query parameter의 team_name 값을 DTO의 teamName으로 매핑하기 위해 아래와 같이 구현했습니다.
  Map<String, String> params로 query parameter 값을 받아옵니다.
  _Multipart-form으로 데이터를 보낼 경우 이미지 파일 외의 데이터는 query parameter 형식으로 들어와서 query parameter를 활용했습니다._
  ```java
     ObjectMapper mapper = new ObjectMapper();
     CreateTeamRequestDto createTeamRequestDto = mapper.convertValue(params, CreateTeamRequestDto.class);
  ```

## 📝 Review Note
<!-- PR과정에서 든 생각이나 개선할 내용이 있다면 적어주세요. -->
reflection을 생성할 때 디폴트 값(SettingRequired)를 적용시키고 싶었는데 잘 안돼서 값을 직접 넣어주도록 구현했습니다.
현재는 이미지 업로드 -> 유저 팀 합류 순으로 수행되기 때문에, 이미지 업로드 후 에러 발생시 이미 업로드된 이미지가 삭제되도록 하거나 이미지 업로드쪽 구현 방식을 바꾸면 좋을 것 같습니다.

## 📣 Related Issue
<!-- 관련 이슈를 적어주세요. -->
- close #31 


## 📬 Reference
<!-- 참고한 코드의 출처를 작성해주세요 -->
- 팀 코드 생성
  https://www.baeldung.com/java-random-string
- ObjectMapper 사용 (query parameter - DTO mapping)
  https://tailerbox.tistory.com/30