### PR TITLE
[FEAT] 팀에서 나가기 API(userLeaveTeam) 구현

### DIFF
--- a/src/main/java/maddori/keygo/common/util/ImageHandler.java
+++ b/src/main/java/maddori/keygo/common/util/ImageHandler.java
@@ -11,6 +11,10 @@ import java.util.Date;
 import static maddori.keygo.common.response.ResponseCode.*;
 
 public class ImageHandler {
+
+    // 이미지가 저장되는 서버 경로
+    static String absolutePath = new File("").getAbsolutePath() + "/src/main/resources/static/";
+
     public static String imageUpload(MultipartFile profileImage) throws IOException {
         // 이미지 파일인지 체크
         String contentType = profileImage.getContentType();
@@ -18,7 +22,6 @@ public class ImageHandler {
 
         // Todo: S3 업로드로 변경
         // project root path/src/images/ 에 사진 저장, 디렉토리 없다면 자동 생성
-        String absolutePath = new File("").getAbsolutePath() + "/src/main/resources/static/";
         File directory = new File(absolutePath + "images/");
         if (!directory.exists()) directory.mkdirs();
 
@@ -48,6 +51,12 @@ public class ImageHandler {
         profileImage.transferTo(file);
 
         return path;
+    }
+
+    public static void imageDelete(String path) {
+        System.out.println(absolutePath + path);
+        File file = new File(absolutePath + path);
+        if(!file.delete()) throw new RuntimeException();
     }
 
 }

--- a/src/main/java/maddori/keygo/controller/UserController.java
+++ b/src/main/java/maddori/keygo/controller/UserController.java
@@ -3,6 +3,7 @@ package maddori.keygo.controller;
 import lombok.RequiredArgsConstructor;
 import maddori.keygo.common.response.BasicResponse;
 import maddori.keygo.common.response.FailResponse;
+import maddori.keygo.common.response.NoDetailSuccessResponse;
 import maddori.keygo.common.response.SuccessResponse;
 import maddori.keygo.dto.user.UserTeamListResponseDto;
 import maddori.keygo.dto.user.UserTeamRequestDto;
@@ -40,4 +41,10 @@ public class UserController {
         return SuccessResponse.toResponseEntity(USER_JOIN_TEAM_SUCCESS, userTeamResponseDto);
     }
 
+    @DeleteMapping("team/{teamId}/leave")
+    public ResponseEntity<? extends BasicResponse> userLeaveTeam(@RequestHeader("user_id") Long userId,
+                                                                 @PathVariable("teamId") Long teamId) {
+        userService.userLeaveTeam(userId, teamId);
+        return NoDetailSuccessResponse.toResponseEntity(WITHDRAW_TEAM_SUCCESS);
+    }
 }

--- a/src/main/java/maddori/keygo/repository/UserTeamRepository.java
+++ b/src/main/java/maddori/keygo/repository/UserTeamRepository.java
@@ -10,4 +10,5 @@ import java.util.Optional;
 public interface UserTeamRepository extends JpaRepository<UserTeam, Long> {
     List<UserTeam> findUserTeamsByUserId(Long userId);
     Optional<UserTeam> findByUserIdAndTeamId(Long userId, Long teamId);
+    void deleteByUserIdAndTeamId(Long userId, Long teamId);
 }

--- a/src/main/java/maddori/keygo/service/UserService.java
+++ b/src/main/java/maddori/keygo/service/UserService.java
@@ -79,4 +79,13 @@ public class UserService {
 
         return response;
     }
+
+
+    @Transactional
+    public void userLeaveTeam(Long userId, Long teamId) {
+        // 프로필 이미지 삭제
+        ImageHandler.imageDelete(userTeamRepository.findByUserIdAndTeamId(userId, teamId).get().getProfileImagePath());
+        // userteam에서 데이터 삭제
+        userTeamRepository.deleteByUserIdAndTeamId(userId, teamId);
+    }
 }


### PR DESCRIPTION
## 📝 Summary
<!-- 해당 PR의 주요 내용을 적어주세요 -->
요청을 보낸 유저가 특정 팀에서 탈퇴한다

## 👩‍💻 Contents
<!-- 작업 내용을 적어주세요 -->
- 응답 (detail X)
    ```json
  {
    "success": true,
    "message": "유저 팀 탈퇴 성공"
  }
  ```
- ImageHandler
  - imageDelete 메서드 구현 : 팀에서 사용했던 프로필의 이미지 삭제
  - 이미지 저장 경로 필드를 static 필드로 변경

## 📝 Review Note
<!-- PR과정에서 든 생각이나 개선할 내용이 있다면 적어주세요. -->
- 추후 유저가 팀에 속하지 않을 때 Exception을 발생시키는 로직 구현 후 필요한 부분에 적용하면 될 것 같습니다

## 📣 Related Issue
<!-- 관련 이슈를 적어주세요. -->
- close #33 


## 📬 Reference
<!-- 참고한 코드의 출처를 작성해주세요 -->
