### PR TITLE
[FEAT] 회원 탈퇴(signOut) API 구현

### DIFF
--- a/src/main/java/maddori/keygo/controller/AuthController.java
+++ b/src/main/java/maddori/keygo/controller/AuthController.java
@@ -1,0 +1,14 @@
+package maddori.keygo.controller;
+
+import lombok.RequiredArgsConstructor;
+import maddori.keygo.service.AuthService;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("api/v2/teams")
+public class AuthController {
+    private final AuthService authService;
+
+}

--- a/src/main/java/maddori/keygo/controller/AuthController.java
+++ b/src/main/java/maddori/keygo/controller/AuthController.java
@@ -14,11 +14,11 @@ import static maddori.keygo.common.response.ResponseCode.GET_TEAM_INFO_SUCCESS;
 
 @RestController
 @RequiredArgsConstructor
-@RequestMapping("api/v2/")
+@RequestMapping("api/v2/auth/")
 public class AuthController {
     private final AuthService authService;
 
-    @DeleteMapping("login/signOut")
+    @DeleteMapping("signOut")
     public ResponseEntity<? extends BasicResponse> getCertainTeamDetail(@RequestHeader("user_id") Long userId) {
         authService.deleteUser(userId);
         return NoDetailSuccessResponse.toResponseEntity(DELETE_USER_SUCCESS);

--- a/src/main/java/maddori/keygo/controller/AuthController.java
+++ b/src/main/java/maddori/keygo/controller/AuthController.java
@@ -19,7 +19,7 @@ public class AuthController {
     private final AuthService authService;
 
     @DeleteMapping("signOut")
-    public ResponseEntity<? extends BasicResponse> getCertainTeamDetail(@RequestHeader("user_id") Long userId) {
+    public ResponseEntity<? extends BasicResponse> signOut(@RequestHeader("user_id") Long userId) {
         authService.deleteUser(userId);
         return NoDetailSuccessResponse.toResponseEntity(DELETE_USER_SUCCESS);
     }

--- a/src/main/java/maddori/keygo/controller/AuthController.java
+++ b/src/main/java/maddori/keygo/controller/AuthController.java
@@ -1,14 +1,27 @@
 package maddori.keygo.controller;
 
 import lombok.RequiredArgsConstructor;
+import maddori.keygo.common.response.BasicResponse;
+import maddori.keygo.common.response.NoDetailSuccessResponse;
+import maddori.keygo.common.response.SuccessResponse;
+import maddori.keygo.dto.team.TeamResponseDto;
 import maddori.keygo.service.AuthService;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+import static maddori.keygo.common.response.ResponseCode.DELETE_USER_SUCCESS;
+import static maddori.keygo.common.response.ResponseCode.GET_TEAM_INFO_SUCCESS;
 
 @RestController
 @RequiredArgsConstructor
-@RequestMapping("api/v2/teams")
+@RequestMapping("api/v2/")
 public class AuthController {
     private final AuthService authService;
+
+    @DeleteMapping("login/signOut")
+    public ResponseEntity<? extends BasicResponse> getCertainTeamDetail(@RequestHeader("user_id") Long userId) {
+        authService.deleteUser(userId);
+        return NoDetailSuccessResponse.toResponseEntity(DELETE_USER_SUCCESS);
+    }
 
 }

--- a/src/main/java/maddori/keygo/repository/FeedbackRepository.java
+++ b/src/main/java/maddori/keygo/repository/FeedbackRepository.java
@@ -2,8 +2,15 @@ package maddori.keygo.repository;
 
 import maddori.keygo.domain.entity.Feedback;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
 public interface FeedbackRepository extends JpaRepository<Feedback, Long> {
 
     public void deleteById(Long id);
+
+    @Modifying(clearAutomatically = true)
+    @Query(value = "update feedback f set f.from_id = null where f.from_id = :userId", nativeQuery = true)
+    void fromUserSetNull(@Param("userId") Long userId);
 }

--- a/src/main/java/maddori/keygo/repository/FeedbackRepository.java
+++ b/src/main/java/maddori/keygo/repository/FeedbackRepository.java
@@ -13,7 +13,7 @@ public interface FeedbackRepository extends JpaRepository<Feedback, Long> {
     public void deleteById(Long id);
 
     @Modifying(clearAutomatically = true)
-    @Query(value = "update feedback f set f.from_id = null where f.from_id = :userId", nativeQuery = true)
+    @Query("update Feedback f set f.fromUser = null where f.fromUser.id = :userId")
     void fromUserSetNull(@Param("userId") Long userId);
 
     public List<Feedback> findAllByTypeAndReflectionId(CssType type, Long reflectionId);

--- a/src/main/java/maddori/keygo/service/AuthService.java
+++ b/src/main/java/maddori/keygo/service/AuthService.java
@@ -2,7 +2,7 @@ package maddori.keygo.service;
 
 import lombok.RequiredArgsConstructor;
 import maddori.keygo.common.exception.CustomException;
-import maddori.keygo.common.response.ResponseCode;
+import maddori.keygo.repository.FeedbackRepository;
 import maddori.keygo.repository.UserRepository;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -13,10 +13,12 @@ import static maddori.keygo.common.response.ResponseCode.*;
 @RequiredArgsConstructor
 public class AuthService {
     private final UserRepository userRepository;
+    private final FeedbackRepository feedbackRepository;
 
     @Transactional
     public void deleteUser(Long userId) {
         userRepository.delete(userRepository.findById(userId).orElseThrow(() ->
                                                     new CustomException(USER_NOT_EXIST)));
+        feedbackRepository.fromUserSetNull(userId);
     }
 }

--- a/src/main/java/maddori/keygo/service/AuthService.java
+++ b/src/main/java/maddori/keygo/service/AuthService.java
@@ -1,11 +1,22 @@
 package maddori.keygo.service;
 
 import lombok.RequiredArgsConstructor;
+import maddori.keygo.common.exception.CustomException;
+import maddori.keygo.common.response.ResponseCode;
 import maddori.keygo.repository.UserRepository;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import static maddori.keygo.common.response.ResponseCode.*;
 
 @Service
 @RequiredArgsConstructor
 public class AuthService {
     private final UserRepository userRepository;
+
+    @Transactional
+    public void deleteUser(Long userId) {
+        userRepository.delete(userRepository.findById(userId).orElseThrow(() ->
+                                                    new CustomException(USER_NOT_EXIST)));
+    }
 }

--- a/src/main/java/maddori/keygo/service/AuthService.java
+++ b/src/main/java/maddori/keygo/service/AuthService.java
@@ -1,0 +1,11 @@
+package maddori.keygo.service;
+
+import lombok.RequiredArgsConstructor;
+import maddori.keygo.repository.UserRepository;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class AuthService {
+    private final UserRepository userRepository;
+}


### PR DESCRIPTION
## 📝 Summary
<!-- 해당 PR의 주요 내용을 적어주세요 -->
회원 탈퇴(signOut) API 구현
- 유저가 보낸 피드백은 삭제하지 않습니다 (feedback의 from_id 부분을 null로 업데이트)

## 👩‍💻 Contents
<!-- 작업 내용을 적어주세요 -->
- user 테이블에서 회원 삭제하도록 구현
  회원 존재하지 않을시 그에 맞는 Exception 반환
- feedback에서 삭제된 회원이 보낸 피드백의 from_id를 NULL로 업데이트
  아래처럼 bulkUpdate 구현했고, 캐시-디비 데이터 싱크를 맞춰야한다고 해서 `clearAutomatically = true`옵션 넣어줬습니다.
  ```java
    @Modifying(clearAutomatically = true)
    @Query(value = "update feedback f set f.from_id = null where f.from_id = :userId", nativeQuery = true)
    void fromUserSetNull(@Param("userId") Long userId);
  ```

## 📝 Review Note
<!-- PR과정에서 든 생각이나 개선할 내용이 있다면 적어주세요. -->
요청을 보낸 유저의 회원 탈퇴를 진행하며, 유저 관련 정보(username, email, refresh_token, 유저의 팀 관계, 유저가 받은 피드백)을 삭제합니다. -> 이 부분은 따로 이슈 파서 전반적인 cascade 설정 넣는걸로 하겠습니다

## 📣 Related Issue
<!-- 관련 이슈를 적어주세요. -->
- close #37 


## 📬 Reference
<!-- 참고한 코드의 출처를 작성해주세요 -->
- bulk update
  https://jaehoney.tistory.com/151
  https://devhyogeon.tistory.com/4
