### PR TITLE
[FEAT] S3 이미지 업로드 구현

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -25,6 +25,7 @@ dependencies {
 	implementation 'org.springframework.boot:spring-boot-starter-web'
 	implementation 'com.google.code.gson:gson:2.10.1'
 	implementation 'io.jsonwebtoken:jjwt-api:0.11.5'
+	implementation 'org.springframework.cloud:spring-cloud-starter-aws:2.2.6.RELEASE'
 	runtimeOnly 'io.jsonwebtoken:jjwt-impl:0.11.5',
 			'io.jsonwebtoken:jjwt-jackson:0.11.5'
 	compileOnly 'org.projectlombok:lombok'

--- a/build.gradle
+++ b/build.gradle
@@ -26,6 +26,7 @@ dependencies {
 	implementation 'com.google.code.gson:gson:2.10.1'
 	implementation 'io.jsonwebtoken:jjwt-api:0.11.5'
 	implementation 'org.springframework.cloud:spring-cloud-starter-aws:2.2.6.RELEASE'
+	implementation 'javax.xml.bind:jaxb-api:2.3.1'
 	runtimeOnly 'io.jsonwebtoken:jjwt-impl:0.11.5',
 			'io.jsonwebtoken:jjwt-jackson:0.11.5'
 	compileOnly 'org.projectlombok:lombok'

--- a/src/main/java/maddori/keygo/common/util/ImageHandler.java
+++ b/src/main/java/maddori/keygo/common/util/ImageHandler.java
@@ -1,6 +1,11 @@
 package maddori.keygo.common.util;
 
+import com.amazonaws.services.s3.AmazonS3Client;
+import com.amazonaws.services.s3.model.PutObjectRequest;
+import lombok.RequiredArgsConstructor;
 import maddori.keygo.common.exception.CustomException;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Component;
 import org.springframework.web.multipart.MultipartFile;
 
 import java.io.File;
@@ -10,12 +15,20 @@ import java.util.Date;
 
 import static maddori.keygo.common.response.ResponseCode.*;
 
+@Component
+@RequiredArgsConstructor
 public class ImageHandler {
 
     // 이미지가 저장되는 서버 경로
-    static String absolutePath = new File("").getAbsolutePath() + "/src/main/resources/static/";
+    private String absolutePath = new File("").getAbsolutePath() + "/src/main/resources/static/";
 
-    public static String imageUpload(MultipartFile profileImage) throws IOException {
+    // s3 관련
+    private final AmazonS3Client amazonS3Client;
+
+    @Value("${cloud.aws.s3.bucket}")
+    private String bucket;
+
+    public String imageUpload(MultipartFile profileImage) throws IOException {
         // 이미지 파일인지 체크
         String contentType = profileImage.getContentType();
         if (!contentType.contains("image")) throw new CustomException(PROFILE_IMAGE_FORMAT_ERROR);
@@ -53,10 +66,45 @@ public class ImageHandler {
         return path;
     }
 
-    public static void imageDelete(String path) {
-        System.out.println(absolutePath + path);
+    public void imageDelete(String path) {
         File file = new File(absolutePath + path);
         if(!file.delete()) throw new RuntimeException();
+    }
+
+    public String imageUploadS3(MultipartFile profileImage) throws IOException {
+        // 이미지 파일인지 체크
+        String contentType = profileImage.getContentType();
+        if (!contentType.contains("image")) throw new CustomException(PROFILE_IMAGE_FORMAT_ERROR);
+
+        // 확장자 구하기
+        String extension;
+        switch (contentType) {
+            case "image/png" :
+                extension = ".png";
+                break;
+            case "image/jpg" :
+                extension = ".jpg";
+                break;
+            case "image/jpeg" :
+                extension = ".jpeg";
+                break;
+            default:
+                throw new CustomException(PROFILE_IMAGE_FORMAT_ERROR);
+        }
+
+        // '이미지 파일 명 + 현재 시간 + .확장자'로 파일명 설정
+        // 현재 시간 string으로 변환(milliseconds까지 표시)
+        SimpleDateFormat simpleDateFormat = new SimpleDateFormat("yyyyMMddhhmmssSSS");
+        String currentDate = simpleDateFormat.format(new Date());
+        String fileName = profileImage.getOriginalFilename() + currentDate + extension;
+        String path = "https://" + bucket + "/" + fileName;
+
+        // S3에 업로드
+        amazonS3Client.putObject(
+                new PutObjectRequest(bucket, fileName, (File) profileImage)
+        );
+
+        return path;
     }
 
 }

--- a/src/main/java/maddori/keygo/common/util/ImageHandler.java
+++ b/src/main/java/maddori/keygo/common/util/ImageHandler.java
@@ -28,12 +28,12 @@ public class ImageHandler {
     @Value("${cloud.aws.s3.bucket}")
     private String bucket;
 
-    public String imageUpload(MultipartFile profileImage) throws IOException {
+    // 로컬에 이미지 업로드
+    public File imageUpload(MultipartFile profileImage) throws IOException {
         // 이미지 파일인지 체크
         String contentType = profileImage.getContentType();
         if (!contentType.contains("image")) throw new CustomException(PROFILE_IMAGE_FORMAT_ERROR);
 
-        // Todo: S3 업로드로 변경
         // project root path/src/images/ 에 사진 저장, 디렉토리 없다면 자동 생성
         File directory = new File(absolutePath + "images/");
         if (!directory.exists()) directory.mkdirs();
@@ -63,48 +63,29 @@ public class ImageHandler {
         File file = new File(absolutePath + path);
         profileImage.transferTo(file);
 
-        return path;
+        return file;
     }
 
-    public void imageDelete(String path) {
-        File file = new File(absolutePath + path);
+    // 로컬의 이미지 삭제
+    public void imageDelete(File file) {
         if(!file.delete()) throw new RuntimeException();
     }
 
+    // S3에 이미지 업로드
     public String imageUploadS3(MultipartFile profileImage) throws IOException {
-        // 이미지 파일인지 체크
-        String contentType = profileImage.getContentType();
-        if (!contentType.contains("image")) throw new CustomException(PROFILE_IMAGE_FORMAT_ERROR);
-
-        // 확장자 구하기
-        String extension;
-        switch (contentType) {
-            case "image/png" :
-                extension = ".png";
-                break;
-            case "image/jpg" :
-                extension = ".jpg";
-                break;
-            case "image/jpeg" :
-                extension = ".jpeg";
-                break;
-            default:
-                throw new CustomException(PROFILE_IMAGE_FORMAT_ERROR);
-        }
-
-        // '이미지 파일 명 + 현재 시간 + .확장자'로 파일명 설정
-        // 현재 시간 string으로 변환(milliseconds까지 표시)
-        SimpleDateFormat simpleDateFormat = new SimpleDateFormat("yyyyMMddhhmmssSSS");
-        String currentDate = simpleDateFormat.format(new Date());
-        String fileName = profileImage.getOriginalFilename() + currentDate + extension;
-        String path = "https://" + bucket + "/" + fileName;
-
+        File localFile = imageUpload(profileImage); // 로컬에 파일 업로드
+        String fileName = localFile.getName();
+        System.out.println("here1");
         // S3에 업로드
         amazonS3Client.putObject(
-                new PutObjectRequest(bucket, fileName, (File) profileImage)
+                new PutObjectRequest(bucket, fileName, localFile)
         );
+        System.out.println("here2");
 
-        return path;
+        // 로컬의 이미지 삭제
+        imageDelete(localFile);
+        System.out.println("here3");
+        return amazonS3Client.getUrl(bucket, fileName).toString();
     }
 
 }

--- a/src/main/java/maddori/keygo/common/util/ImageHandler.java
+++ b/src/main/java/maddori/keygo/common/util/ImageHandler.java
@@ -10,6 +10,7 @@ import org.springframework.web.multipart.MultipartFile;
 
 import java.io.File;
 import java.io.IOException;
+import java.net.URLDecoder;
 import java.text.SimpleDateFormat;
 import java.util.Date;
 
@@ -75,17 +76,23 @@ public class ImageHandler {
     public String imageUploadS3(MultipartFile profileImage) throws IOException {
         File localFile = imageUpload(profileImage); // 로컬에 파일 업로드
         String fileName = localFile.getName();
-        System.out.println("here1");
+
         // S3에 업로드
         amazonS3Client.putObject(
                 new PutObjectRequest(bucket, fileName, localFile)
         );
-        System.out.println("here2");
 
         // 로컬의 이미지 삭제
         imageDelete(localFile);
-        System.out.println("here3");
+
         return amazonS3Client.getUrl(bucket, fileName).toString();
     }
+
+    // S3 이미지 삭제
+    public void imageDeleteS3(String path) {
+        String key = URLDecoder.decode(path.split("/")[3]);
+        amazonS3Client.deleteObject(bucket, key);
+    }
+
 
 }

--- a/src/main/java/maddori/keygo/config/S3Config.java
+++ b/src/main/java/maddori/keygo/config/S3Config.java
@@ -1,0 +1,35 @@
+package maddori.keygo.config;
+
+import com.amazonaws.auth.AWSCredentials;
+import com.amazonaws.auth.AWSStaticCredentialsProvider;
+import com.amazonaws.auth.BasicAWSCredentials;
+import com.amazonaws.services.s3.AmazonS3Client;
+import com.amazonaws.services.s3.AmazonS3ClientBuilder;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.core.env.Environment;
+
+@Configuration
+public class S3Config {
+    private final Environment environment;
+    private final static String region = "ap-northeast-2";
+    private final String accessKey;
+    private final String secretKey;
+
+    public S3Config(Environment environment) {
+        this.environment = environment;
+        this.accessKey = environment.getProperty("s3.accessKey");
+        this.secretKey = environment.getProperty("s3.secretKey");
+    }
+
+    @Bean
+    public AmazonS3Client amazonS3Client() {
+        AWSCredentials credentials = new BasicAWSCredentials(accessKey, secretKey);
+
+        return (AmazonS3Client) AmazonS3ClientBuilder
+                .standard()
+                .withRegion(region)
+                .withCredentials(new AWSStaticCredentialsProvider(credentials))
+                .build();
+    }
+}

--- a/src/main/java/maddori/keygo/service/TeamService.java
+++ b/src/main/java/maddori/keygo/service/TeamService.java
@@ -74,7 +74,7 @@ public class TeamService {
         teamRepository.save(team);
 
         // 프로필 이미지 업로드
-        String profileImagePath = (profileImage == null) ? null : imageHandler.imageUpload(profileImage);
+        String profileImagePath = (profileImage == null) ? null : imageHandler.imageUploadS3(profileImage);
 
         // userteam 테이블 업데이트
         UserTeam userTeam = userTeamRepository.save(UserTeam.builder()

--- a/src/main/java/maddori/keygo/service/TeamService.java
+++ b/src/main/java/maddori/keygo/service/TeamService.java
@@ -33,6 +33,7 @@ public class TeamService {
     private final TeamRepository teamRepository;
     private final ReflectionRepository reflectionRepository;
     private final UserTeamRepository userTeamRepository;
+    private final ImageHandler imageHandler;
 
     @Transactional(readOnly = true)
     public TeamResponseDto getCertainTeam(String teamId) {
@@ -73,7 +74,7 @@ public class TeamService {
         teamRepository.save(team);
 
         // 프로필 이미지 업로드
-        String profileImagePath = (profileImage == null) ? null : ImageHandler.imageUpload(profileImage);
+        String profileImagePath = (profileImage == null) ? null : imageHandler.imageUpload(profileImage);
 
         // userteam 테이블 업데이트
         UserTeam userTeam = userTeamRepository.save(UserTeam.builder()

--- a/src/main/java/maddori/keygo/service/UserService.java
+++ b/src/main/java/maddori/keygo/service/UserService.java
@@ -30,6 +30,7 @@ public class UserService {
     private final UserRepository userRepository;
     private final UserTeamRepository userTeamRepository;
     private final TeamRepository teamRepository;
+    private final ImageHandler imageHandler;
 
     @Transactional(readOnly = true)
     public List<UserTeamListResponseDto> getUserTeamList(Long userId) {
@@ -53,7 +54,7 @@ public class UserService {
         // 이미 합류한 팀인지 체크
         if (userTeamRepository.findUserTeamsByUserIdAndTeamId(userId, teamId).isPresent()) throw new CustomException(ALREADY_TEAM_MEMBER);
 
-        String profileImagePath = (profileImage == null) ? null : ImageHandler.imageUpload(profileImage);
+        String profileImagePath = (profileImage == null) ? null : imageHandler.imageUpload(profileImage);
 
         // userteam 테이블 업데이트
         UserTeam userTeam = userTeamRepository.save(UserTeam.builder()
@@ -84,7 +85,7 @@ public class UserService {
     @Transactional
     public void userLeaveTeam(Long userId, Long teamId) {
         // 프로필 이미지 삭제
-        ImageHandler.imageDelete(userTeamRepository.findUserTeamsByUserIdAndTeamId(userId, teamId).get().getProfileImagePath());
+        imageHandler.imageDelete(userTeamRepository.findUserTeamsByUserIdAndTeamId(userId, teamId).get().getProfileImagePath());
         // userteam에서 데이터 삭제
         userTeamRepository.deleteByUserIdAndTeamId(userId, teamId);
     }

--- a/src/main/java/maddori/keygo/service/UserService.java
+++ b/src/main/java/maddori/keygo/service/UserService.java
@@ -54,7 +54,7 @@ public class UserService {
         // 이미 합류한 팀인지 체크
         if (userTeamRepository.findUserTeamsByUserIdAndTeamId(userId, teamId).isPresent()) throw new CustomException(ALREADY_TEAM_MEMBER);
 
-        String profileImagePath = (profileImage == null) ? null : imageHandler.imageUpload(profileImage);
+        String profileImagePath = (profileImage == null) ? null : imageHandler.imageUploadS3(profileImage);
 
         // userteam 테이블 업데이트
         UserTeam userTeam = userTeamRepository.save(UserTeam.builder()
@@ -85,7 +85,7 @@ public class UserService {
     @Transactional
     public void userLeaveTeam(Long userId, Long teamId) {
         // 프로필 이미지 삭제
-        imageHandler.imageDelete(userTeamRepository.findUserTeamsByUserIdAndTeamId(userId, teamId).get().getProfileImagePath());
+//        imageHandler.imageDelete(userTeamRepository.findUserTeamsByUserIdAndTeamId(userId, teamId).get().getProfileImagePath());
         // userteam에서 데이터 삭제
         userTeamRepository.deleteByUserIdAndTeamId(userId, teamId);
     }

--- a/src/main/java/maddori/keygo/service/UserService.java
+++ b/src/main/java/maddori/keygo/service/UserService.java
@@ -85,7 +85,7 @@ public class UserService {
     @Transactional
     public void userLeaveTeam(Long userId, Long teamId) {
         // 프로필 이미지 삭제
-//        imageHandler.imageDelete(userTeamRepository.findUserTeamsByUserIdAndTeamId(userId, teamId).get().getProfileImagePath());
+        imageHandler.imageDeleteS3(userTeamRepository.findUserTeamsByUserIdAndTeamId(userId, teamId).get().getProfileImagePath());
         // userteam에서 데이터 삭제
         userTeamRepository.deleteByUserIdAndTeamId(userId, teamId);
     }

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -31,3 +31,9 @@ spring:
       enabled: true
     restart:
       enabled: true
+
+cloud:
+  aws:
+    s3:
+      bucket: keygo
+      stack.auto: false


### PR DESCRIPTION
## 📝 Summary
<!-- 해당 PR의 주요 내용을 적어주세요 -->
기존에 서버에 업로드되던 프로필 이미지가 S3에 업로드될 수 있도록 구현했습니다.
- 유저가 팀에서 사용할 프로필을 만들면 프로필 이미지가 S3에 업로드되고 URL이 DB에 저장됩니다.
- 유저가 팀에서 탈퇴하면 사용하던 팀 프로필 이미지가 S3에서 삭제됩니다.

## 👩‍💻 Contents
<!-- 작업 내용을 적어주세요 -->
- **imageUploadS3 구현**
  S3에 이미지를 업로드하기 위해서는 로컬에 저장된 이미지를 이용해야 하기 때문에 아래 로직을 따르도록 구현했습니다.
  1. 로컬에 이미지 업로드
  2. S3에 이미지 업로드
  3. 로컬에 업로드된 이미지 삭제
- **imageDeleteS3 구현**
  S3에 업로드된 이미지를 삭제합니다
- **S3 설정 관리**
   application-config.yml에 아래 변수를 추가합니다
   `s3.accessKey`  `s3.secretKey`
- **AmazonS3Client 생성**
   s3에 접근하기 위한 설정 정보를 바탕으로 파일 업로드, 삭제 작업을 수행할 수 있는 `AmazonS3Client`를 생성합니다.

## 📝 Review Note
<!-- PR과정에서 든 생각이나 개선할 내용이 있다면 적어주세요. -->
유저가 앱을 탈퇴하는 경우 유저의 프로필 이미지를 모두 삭제하는 부분이 추가로 구현되면 좋을 것 같습니다!

## 📣 Related Issue
<!-- 관련 이슈를 적어주세요. -->
- close #58 


## 📬 Reference
<!-- 참고한 코드의 출처를 작성해주세요 -->
- Spring, S3 파일 업로드
  https://gaeggu.tistory.com/33
  https://velog.io/@chaeri93/SpringBoot-AWS-S3%EB%A1%9C-%EC%9D%B4%EB%AF%B8%EC%A7%80-%EC%97%85%EB%A1%9C%EB%93%9C%ED%95%98%EA%B8%B0