### PR TITLE
[FEAT] application-config.yml에서 환경 변수 값 가져올 수 있도록 수정

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -38,6 +38,5 @@ out/
 ### VS Code ###
 .vscode/
 
-application.yml
 application-config.yml
 .DS_Store

--- a/src/main/java/maddori/keygo/security/JwtHandler.java
+++ b/src/main/java/maddori/keygo/security/JwtHandler.java
@@ -2,21 +2,20 @@ package maddori.keygo.security;
 
 import io.jsonwebtoken.Jwts;
 import io.jsonwebtoken.SignatureAlgorithm;
-import org.springframework.core.env.Environment;
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Component;
 
 import java.util.Date;
 
 @Component
 public class JwtHandler {
-    private final Environment environment;
+    @Value("${jwt.secret}")
     private final String secretKey;
     private static final Long accessExpiration = 1000L * 60 * 60 * 24 * 365;
     private static final Long refreshExpiration = 1000L * 60 * 60 * 24 * 365 * 2;
 
-    public JwtHandler(Environment environment) {
-        this.environment = environment;
-        this.secretKey = environment.getProperty("jwt.secret");
+    public JwtHandler(@Value("${jwt.secret}") String secretKey) {
+        this.secretKey = secretKey;
     }
 
     // accessToken 생성

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -1,0 +1,39 @@
+server:
+  port: 8080
+
+spring:
+  config:
+    import: application-config.yml
+  datasource:
+    url: jdbc:h2:tcp://localhost/~/keygo;NON_KEYWORDS=USER;DATABASE_TO_UPPER=false;
+    username: sa
+    password:
+    driver-class-name: org.h2.Driver
+  h2:
+    console:
+      enabled: true
+      path: /h2-console
+      settings:
+        web-allow-others: true
+  mvc:
+    pathmatch:
+      matching-strategy: ant_path_matcher
+  jpa:
+    hibernate:
+      ddl-auto: create
+    properties:
+      hibernate:
+        show_sql: true
+        format_sql: true
+        dialect: org.hibernate.dialect.H2Dialect
+  devtools:
+    livereload:
+      enabled: true
+    restart:
+      enabled: true
+
+cloud:
+  aws:
+    s3:
+      bucket: keygo
+      stack.auto: false


### PR DESCRIPTION
## 📝 Summary
<!-- 해당 PR의 주요 내용을 적어주세요 -->
application-config.yml에서 환경 변수 값 가져올 수 있도록 수정
(AppConfig에서 application-config.yml에서 환경 변수를 가져올 수 있도록 설정해두었습니다)
- 이전
  application.yml 파일에 환경 변수 값 설정, @ Value로 가져오기 + Environment 활용하기 혼용
- 이후
  application-config.yml 파일에 환경 변수 값 설정, @ Value로 가져오기만 사용

## 👩‍💻 Contents
<!-- 작업 내용을 적어주세요 -->
- JwtHandler 환경변수 가져오는 방식 @ Value 사용하도록 변경
- application.yml 에서 주요 정보 삭제, git에 업로드되도록 설정
- application-config.yml에 환경 변수 추가
  jwt.secret, s3.accessKey, s3.secretKey

## 📝 Review Note
<!-- PR과정에서 든 생각이나 개선할 내용이 있다면 적어주세요. -->


## 📣 Related Issue
<!-- 관련 이슈를 적어주세요. -->
- close #64 


## 📬 Reference
<!-- 참고한 코드의 출처를 작성해주세요 -->
