### PR TITLE
[CHORE] reflection date 'yyyy-MM-dd HH:mm:ss' 형식으로 통일

### DIFF
--- a/src/main/java/maddori/keygo/dto/reflection/ReflectionCurrentResponseDto.java
+++ b/src/main/java/maddori/keygo/dto/reflection/ReflectionCurrentResponseDto.java
@@ -1,9 +1,11 @@
 package maddori.keygo.dto.reflection;
 
+import com.fasterxml.jackson.annotation.JsonFormat;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import lombok.Builder;
 import lombok.Data;
 
+import java.time.LocalDateTime;
 import java.util.List;
 
 @Data
@@ -16,7 +18,8 @@ public class ReflectionCurrentResponseDto {
     private String reflectionName;
 
     @JsonProperty("reflection_date")
-    private String reflectionDate;
+    @JsonFormat(pattern = "yyyy-MM-dd HH:mm:ss")
+    private LocalDateTime reflectionDate;
 
     @JsonProperty("reflection_status")
     private String reflectionStatus;
@@ -26,7 +29,7 @@ public class ReflectionCurrentResponseDto {
 
     @Builder
 
-    public ReflectionCurrentResponseDto(Long id, String reflectionName, String reflectionDate, String reflectionStatus, List<String> reflectionKeywords) {
+    public ReflectionCurrentResponseDto(Long id, String reflectionName, LocalDateTime reflectionDate, String reflectionStatus, List<String> reflectionKeywords) {
         this.id = id;
         this.reflectionName = reflectionName;
         this.reflectionDate = reflectionDate;

--- a/src/main/java/maddori/keygo/dto/reflection/ReflectionResponseDto.java
+++ b/src/main/java/maddori/keygo/dto/reflection/ReflectionResponseDto.java
@@ -1,5 +1,6 @@
 package maddori.keygo.dto.reflection;
 
+import com.fasterxml.jackson.annotation.JsonFormat;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import lombok.Builder;
 import lombok.Data;
@@ -14,6 +15,7 @@ public class ReflectionResponseDto {
 
     @JsonProperty("reflection_name")
     private String reflectionName;
+    @JsonFormat(pattern = "yyyy-MM-dd HH:mm:ss")
     private LocalDateTime date;
     private ReflectionState state;
 

--- a/src/main/java/maddori/keygo/dto/reflection/ReflectionUpdateRequestDto.java
+++ b/src/main/java/maddori/keygo/dto/reflection/ReflectionUpdateRequestDto.java
@@ -1,12 +1,11 @@
 package maddori.keygo.dto.reflection;
 
+import com.fasterxml.jackson.annotation.JsonFormat;
 import com.fasterxml.jackson.annotation.JsonProperty;
-import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.Size;
 import lombok.Builder;
 import lombok.Data;
 import lombok.NoArgsConstructor;
-import org.springframework.format.annotation.DateTimeFormat;
 
 import java.time.LocalDateTime;
 
@@ -19,7 +18,7 @@ public class ReflectionUpdateRequestDto {
     private String reflectionName;
 
     @JsonProperty("reflection_date")
-    @DateTimeFormat(pattern = "yyyy-MM-dd HH:mm:ss")
+    @JsonFormat(pattern = "yyyy-MM-dd HH:mm:ss")
     private LocalDateTime reflectionDate;
 
     @Builder

--- a/src/main/java/maddori/keygo/dto/reflection/ReflectionUpdateResponseDto.java
+++ b/src/main/java/maddori/keygo/dto/reflection/ReflectionUpdateResponseDto.java
@@ -1,8 +1,11 @@
 package maddori.keygo.dto.reflection;
 
+import com.fasterxml.jackson.annotation.JsonFormat;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import lombok.Builder;
 import lombok.Data;
+
+import java.time.LocalDateTime;
 
 @Data
 public class ReflectionUpdateResponseDto {
@@ -11,7 +14,8 @@ public class ReflectionUpdateResponseDto {
     @JsonProperty("reflection_name")
     private String reflectionName;
     @JsonProperty("date")
-    private String reflectionDate;
+    @JsonFormat(pattern = "yyyy-MM-dd HH:mm:ss")
+    private LocalDateTime reflectionDate;
     @JsonProperty("state")
     private String reflectionState;
     @JsonProperty("team_id")
@@ -19,7 +23,7 @@ public class ReflectionUpdateResponseDto {
 
     @Builder
 
-    public ReflectionUpdateResponseDto(Long id, String reflectionName, String reflectionDate, String reflectionState, Long teamId) {
+    public ReflectionUpdateResponseDto(Long id, String reflectionName, LocalDateTime reflectionDate, String reflectionState, Long teamId) {
         this.id = id;
         this.reflectionName = reflectionName;
         this.reflectionDate = reflectionDate;

--- a/src/main/java/maddori/keygo/service/ReflectionService.java
+++ b/src/main/java/maddori/keygo/service/ReflectionService.java
@@ -89,7 +89,7 @@ public class ReflectionService {
         return ReflectionUpdateResponseDto.builder()
                 .id(reflection.getId())
                 .reflectionName(reflection.getReflectionName())
-                .reflectionDate(reflection.getDate().toString())
+                .reflectionDate(reflection.getDate())
                 .reflectionState(reflection.getState().toString())
                 .teamId(reflection.getTeam().getId())
                 .build();
@@ -113,7 +113,7 @@ public class ReflectionService {
         return ReflectionCurrentResponseDto.builder()
                 .id(reflection.getId())
                 .reflectionName(reflection.getReflectionName())
-                .reflectionDate(reflection.getDate().toString())
+                .reflectionDate(reflection.getDate())
                 .reflectionStatus(reflection.getState().toString())
                 .reflectionKeywords(keywordList)
                 .build();


### PR DESCRIPTION
## 📝 Summary
<!-- 해당 PR의 주요 내용을 적어주세요 -->
Reflection 관련 dto에서 reflectionDate의 형식을 `yyyy-MM-dd HH:mm:ss` 로 통일하고, 일정 값이 LocalDateTime 형식으로 변환되지 않았던 버그를 해결했습니다. 

## 👩‍💻 Contents
<!-- 작업 내용을 적어주세요 -->
- `@JsonFormat(pattern = "yyyy-MM-dd HH:mm:ss")` 지정
- Dto에서 reflectionDate는 LocalDateTime 데이터타입을 가지도록 통일

## 📝 Review Note
<!-- PR과정에서 든 생각이나 개선할 내용이 있다면 적어주세요. -->


## 📣 Related Issue
<!-- 관련 이슈를 적어주세요. -->
- close #66 


## 📬 Reference
<!-- 참고한 코드의 출처를 작성해주세요 -->
