### PR TITLE
[FEAT] 프로필 수정(editProfile) API 구현

### DIFF
--- a/src/main/java/maddori/keygo/controller/UserController.java
+++ b/src/main/java/maddori/keygo/controller/UserController.java
@@ -48,4 +48,12 @@ public class UserController {
         userService.userLeaveTeam(SecurityService.getCurrentUserId(), teamId);
         return NoDetailSuccessResponse.toResponseEntity(WITHDRAW_TEAM_SUCCESS);
     }
+
+    @PatchMapping("teams/{teamId}/profile")
+    public ResponseEntity<? extends BasicResponse> editProfile(@PathVariable("teamId") Long teamId,
+                                                               @RequestPart("profile_image") @Nullable MultipartFile profileImage,
+                                                               UserTeamRequestDto userTeamRequestDto) throws IOException {
+        UserTeamResponseDto userTeamResponseDto = userService.editProfile(SecurityService.getCurrentUserId(), teamId, profileImage, userTeamRequestDto);
+        return SuccessResponse.toResponseEntity(USER_UPDATE_PROFILE_SUCCESS, userTeamResponseDto);
+    }
 }

--- a/src/main/java/maddori/keygo/domain/entity/UserTeam.java
+++ b/src/main/java/maddori/keygo/domain/entity/UserTeam.java
@@ -42,4 +42,16 @@ public class UserTeam {
         this.profileImagePath = profileImagePath;
         this.admin = admin;
     }
+
+    public void updateProfileImagePath(String profileImagePath) {
+        this.profileImagePath = profileImagePath;
+    }
+
+    public void updateNickname(String nickname) {
+        this.nickname = nickname;
+    }
+
+    public void updateRole(String role) {
+        this.role = role;
+    }
 }

--- a/src/main/java/maddori/keygo/service/UserService.java
+++ b/src/main/java/maddori/keygo/service/UserService.java
@@ -65,7 +65,7 @@ public class UserService {
                         .profileImagePath(profileImagePath)
                         .build());
 
-        UserTeamResponseDto response = UserTeamResponseDto.builder()
+        return UserTeamResponseDto.builder()
                 .id(userTeam.getId())
                 .nickname(userTeam.getNickname())
                 .role(userTeam.getRole())
@@ -77,8 +77,6 @@ public class UserService {
                         .invitationCode(team.getInvitationCode())
                         .build())
                 .build();
-
-        return response;
     }
 
 
@@ -88,5 +86,34 @@ public class UserService {
         imageHandler.imageDeleteS3(userTeamRepository.findUserTeamsByUserIdAndTeamId(userId, teamId).get().getProfileImagePath());
         // userteam에서 데이터 삭제
         userTeamRepository.deleteByUserIdAndTeamId(userId, teamId);
+    }
+
+    public UserTeamResponseDto editProfile(Long userId, Long teamId, MultipartFile profileImage, UserTeamRequestDto requestDto) throws IOException {
+        // 유저 정보
+        userRepository.findById(userId).orElseThrow(() -> new CustomException(USER_NOT_EXIST));
+        // 팀의 존재 여부 체크
+        teamRepository.findById(teamId).orElseThrow(() -> new CustomException(TEAM_NOT_EXIST));
+        // 유저가 팀에 속해있는지 체크
+        UserTeam userTeam = userTeamRepository.findUserTeamsByUserIdAndTeamId(userId, teamId).orElseThrow(() -> new CustomException(USER_NOT_TEAM_MEMBER));
+
+        // 이미지, 닉네임, 역할 변경사항 존재한다면 업데이트
+        if (profileImage != null) {
+            if (userTeam.getProfileImagePath() != null) imageHandler.imageDeleteS3(userTeam.getProfileImagePath());
+            userTeam.updateProfileImagePath(imageHandler.imageUploadS3(profileImage));
+        }
+        if (requestDto.getNickname() != null) {
+            userTeam.updateNickname(requestDto.getNickname());
+        }
+        if (requestDto.getRole() != null) {
+            userTeam.updateRole(requestDto.getRole());
+        }
+        userTeamRepository.save(userTeam);
+
+        return UserTeamResponseDto.builder()
+                .id(userId)
+                .nickname(userTeam.getNickname())
+                .role(userTeam.getRole())
+                .profileImagePath(userTeam.getProfileImagePath())
+                .build();
     }
 }


### PR DESCRIPTION
## 📝 Summary
<!-- 해당 PR의 주요 내용을 적어주세요 -->
editProfile API 구현
- 프로필 수정(닉네임, 역할, 프로필 이미지)
- patch로 구현(변경 없는 값은 포함 안하고 요청)

## 👩‍💻 Contents
<!-- 작업 내용을 적어주세요 -->
- editProfile API 구현
   request에 닉네임, 역할, 프로필 이미지의 값이 존재한다면 해당 값으로 업데이트
   _이미지의 경우 기존 이미지 삭제 후 새로운 이미지 업로드 로직 진행_


## 📝 Review Note
<!-- PR과정에서 든 생각이나 개선할 내용이 있다면 적어주세요. -->
editProfile API 구현이 안 되어있었네요,, 죄송합니다.. 앞으로 좀 더 꼼꼼히 백로그 관리를 해보도록 하겠습니다😅

응답에 UserTeamResponseDto를 사용했습니다. 원래는 이 dto의 id가 userteam의 id인데, 이 api에서는 user_id의 id를 넣어줍니다. 맥락상 userteam의 id가 포함되는 것이 맞을 것 같아서, 추후 클라 쪽에 변경 가능한지 물어보고 변경해보도록 하겠습니다!

추후 값 검증 로직 추가 필요합니다.

## 📣 Related Issue
<!-- 관련 이슈를 적어주세요. -->
- close #68 


## 📬 Reference
<!-- 참고한 코드의 출처를 작성해주세요 -->
